### PR TITLE
fix: reject pool creation if pool with spec exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 .PHONY: mockgen
 mockgen: $(MOCKGEN) ## Download mockgen locally if necessary. If wrong version is installed, it will be overwritten.
 $(MOCKGEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/mockgen && $(LOCALBIN)/mockget --version | grep -q $(MOCKGEN_VERSION) || \
+	test -s $(LOCALBIN)/mockgen && $(LOCALBIN)/mockgen --version | grep -q $(MOCKGEN_VERSION) || \
 	GOBIN=$(LOCALBIN) go install go.uber.org/mock/mockgen@$(MOCKGEN_VERSION)
 
 .PHONY: goreleaser

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/mercedes-benz/garm-operator)](https://goreportcard.com/report/github.com/mercedes-benz/garm-operator) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/mercedes-benz/garm-operator?sort=semver)
+
 # garm-operator 
 
 <!-- toc -->

--- a/api/v1alpha1/pool_types_test.go
+++ b/api/v1alpha1/pool_types_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+
+package v1alpha1
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestPoolList_FilterByFields(t *testing.T) {
+	type fields struct {
+		TypeMeta metav1.TypeMeta
+		ListMeta metav1.ListMeta
+		Items    []Pool
+	}
+	type args struct {
+		predicates []Predicate
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		length int
+	}{
+		{
+			name: "pool with spec already exist",
+			fields: fields{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []Pool{
+					{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "ubuntu-2004-large",
+							Namespace: "test",
+						},
+						Spec: PoolSpec{
+							ImageName:    "ubuntu-2004",
+							Flavor:       "large",
+							ProviderName: "openstack",
+							GitHubScopeRef: corev1.TypedLocalObjectReference{
+								Name:     "test",
+								Kind:     "Enterprise",
+								APIGroup: ptr.To[string]("github.com"),
+							},
+						},
+					},
+					{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "ubuntu-2204-large",
+							Namespace: "test",
+						},
+						Spec: PoolSpec{
+							ImageName:    "ubuntu-2204",
+							Flavor:       "large",
+							ProviderName: "openstack",
+							GitHubScopeRef: corev1.TypedLocalObjectReference{
+								Name:     "test",
+								Kind:     "Enterprise",
+								APIGroup: ptr.To[string]("github.com"),
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				predicates: []Predicate{
+					MatchesImage("ubuntu-2204"),
+					MatchesFlavour("large"),
+					MatchesProvider("openstack"),
+					MatchesGitHubScope("test", "Enterprise"),
+				},
+			},
+			length: 1,
+		},
+		{
+			name: "pool with spec does not exist",
+			fields: fields{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []Pool{
+					{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "ubuntu-2004-large",
+							Namespace: "test",
+						},
+						Spec: PoolSpec{
+							ImageName:    "ubuntu-2004",
+							Flavor:       "large",
+							ProviderName: "openstack",
+							GitHubScopeRef: corev1.TypedLocalObjectReference{
+								Name:     "test",
+								Kind:     "Enterprise",
+								APIGroup: ptr.To[string]("github.com"),
+							},
+						},
+					},
+					{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "ubuntu-2204-large",
+							Namespace: "test",
+						},
+						Spec: PoolSpec{
+							ImageName:    "ubuntu-2204",
+							Flavor:       "large",
+							ProviderName: "openstack",
+							GitHubScopeRef: corev1.TypedLocalObjectReference{
+								Name:     "test",
+								Kind:     "Enterprise",
+								APIGroup: ptr.To[string]("github.com"),
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				predicates: []Predicate{
+					MatchesImage("ubuntu-2404"),
+					MatchesFlavour("large"),
+					MatchesProvider("openstack"),
+					MatchesGitHubScope("test", "Enterprise"),
+				},
+			},
+			length: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &PoolList{
+				TypeMeta: tt.fields.TypeMeta,
+				ListMeta: tt.fields.ListMeta,
+				Items:    tt.fields.Items,
+			}
+
+			p.FilterByFields(tt.args.predicates...)
+
+			if len(p.Items) != tt.length {
+				t.Errorf("FilterByFields() = %v, want %v", len(p.Items), tt.length)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2
 	k8s.io/klog/v2 v2.90.1
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.15.0
 )
 
@@ -82,7 +83,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.27.2 // indirect
 	k8s.io/component-base v0.27.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect


### PR DESCRIPTION
in garm, a pool is uniq on imageName, flavor, provider and scope. This fixes the current implementation where we compared the image.tag name with the name of the image referenc itself.

fixes https://github.com/mercedes-benz/garm-operator/issues/2