### PR TITLE
feat: allow image deletion for deleted pools

### DIFF
--- a/api/v1alpha1/image_webhook.go
+++ b/api/v1alpha1/image_webhook.go
@@ -66,8 +66,11 @@ func (i *Image) attachedPools(ctx context.Context) ([]Pool, error) {
 	}
 
 	for _, pool := range pools.Items {
-		if pool.Spec.ImageName == i.Name {
-			result = append(result, pool)
+		// we do not care about pools that are already deleted
+		if pool.GetDeletionTimestamp() == nil {
+			if pool.Spec.ImageName == i.Name {
+				result = append(result, pool)
+			}
 		}
 	}
 

--- a/api/v1alpha1/pool_webhook.go
+++ b/api/v1alpha1/pool_webhook.go
@@ -77,7 +77,7 @@ func (r *Pool) ValidateCreate() (admission.Warnings, error) {
 	if len(poolList.Items) > 0 {
 		existing := poolList.Items[0]
 		return nil, apierrors.NewBadRequest(
-			fmt.Sprintf("can not create pool, pool=%s with same image=%s , flavor=%s  and provider=%s already exists for specified GitHubScope=%s", existing.Name, existing.Spec.ImageName, existing.Spec.Flavor, existing.Spec.ProviderName, existing.Spec.GitHubScopeRef.Name))
+			fmt.Sprintf("can not create pool, pool=%s with same image=%s, flavor=%s and provider=%s already exists for specified GitHubScope=%s", existing.Name, existing.Spec.ImageName, existing.Spec.Flavor, existing.Spec.ProviderName, existing.Spec.GitHubScopeRef.Name))
 	}
 
 	return nil, nil


### PR DESCRIPTION
For pools with a deletion timestamp it's fine to not track this pool where the image is in use.