### PR TITLE
feat: allow image deletion for in-deleting pools

### DIFF
--- a/api/v1alpha1/image_webhook.go
+++ b/api/v1alpha1/image_webhook.go
@@ -66,8 +66,11 @@ func (i *Image) attachedPools(ctx context.Context) ([]Pool, error) {
 	}
 
 	for _, pool := range pools.Items {
-		if pool.Spec.ImageName == i.Name {
-			result = append(result, pool)
+		// we do not care about pools that are already deleted
+		if pool.GetDeletionTimestamp() == nil {
+			if pool.Spec.ImageName == i.Name {
+				result = append(result, pool)
+			}
 		}
 	}
 


### PR DESCRIPTION
if a pool has a deletionTimestamp set, it's fine to not validate the pool-CR again to force the deletion of the CR


# logmessages


## create image and pool 
```
I1025 12:38:29.101801       1 image_webhook.go:33] image-resource "msg"="validate create" "name"="runner-default-mario"
I1025 12:38:32.684946       1 pool_webhook.go:41] pool-resource "msg"="validate create" "name"="mario01"
I1025 12:38:33.376533       1 pool_webhook.go:88] pool-resource "msg"="validate update" "name"="mario01" "namespace"="garm-infra-stage-int"
I1025 12:38:33.376584       1 pool_webhook.go:147] pool-resource "msg"="validate spec.providerName" "spec.providerName"="os02.fra-prod3"
I1025 12:38:33.376596       1 pool_webhook.go:177] pool-resource "msg"="validate spec.githubScopeRef" "spec.githubScopeRef"={"apiGroup":"garm-operator.mercedes-benz.com","kind":"Organization","name":"github-actions"}
I1025 12:38:33.392815       1 pool_controller.go:131]  "msg"="status.ID is empty and pool doesn't exist on garm side. Creating new pool in garm" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="d0e5c97a-c285-4a90-93ab-be10c3d99af1"
I1025 12:38:33.392868       1 pool_controller.go:435]  "msg"="Getting existing garm pools by pool.spec" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="d0e5c97a-c285-4a90-93ab-be10c3d99af1"
I1025 12:38:33.395997       1 pool_controller.go:144]  "msg"="creating pool" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="d0e5c97a-c285-4a90-93ab-be10c3d99af1"
I1025 12:38:33.459959       1 pool_controller.go:137]  "msg"="creating pool in garm succeeded" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="d0e5c97a-c285-4a90-93ab-be10c3d99af1"
I1025 12:38:34.166757       1 pool_controller.go:230]  "msg"="existing pool found in garm, updating..." "ID"="f8520d8b-d7ce-417d-aeef-9b7d86f74f1c" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="1dde88bd-92f3-4e57-9579-14b966ceeb63"
```

## deleting pool and after pool still exist in `garm` but has an deletionTimestamp in k8s

```
I1025 12:38:47.173016       1 pool_controller.go:283]  "msg"="Deleting Pool" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "pool"="mario01" "reconcileID"="ca349d30-cc2f-42e6-972d-bc574edfca63"
I1025 12:38:47.281830       1 pool_webhook.go:88] pool-resource "msg"="validate update" "name"="mario01" "namespace"="garm-infra-stage-int"
I1025 12:38:47.341369       1 pool_controller.go:315]  "msg"="scaling pool down before deleting" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="ca349d30-cc2f-42e6-972d-bc574edfca63"
I1025 12:38:47.968814       1 pool_controller.go:283]  "msg"="Deleting Pool" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "pool"="mario01" "reconcileID"="1074cdab-e432-4664-8074-563356488d2d"
I1025 12:38:47.970584       1 pool_controller.go:339]  "msg"="Runner is in state that does not allow deletion" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="1074cdab-e432-4664-8074-563356488d2d" "runner"="int-road-runner-mario-s4YJFIhlFpLV" "state"="creating"
I1025 12:38:47.970621       1 pool_controller.go:339]  "msg"="Runner is in state that does not allow deletion" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="1074cdab-e432-4664-8074-563356488d2d" "runner"="int-road-runner-mario-zaynlkDkZ49N" "state"="creating"
I1025 12:38:47.970655       1 pool_controller.go:339]  "msg"="Runner is in state that does not allow deletion" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="1074cdab-e432-4664-8074-563356488d2d" "runner"="int-road-runner-mario-DQksDNCZHxqa" "state"="creating"
I1025 12:38:47.970679       1 pool_controller.go:339]  "msg"="Runner is in state that does not allow deletion" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="1074cdab-e432-4664-8074-563356488d2d" "runner"="int-road-runner-mario-DqjBcLf5w0dh" "state"="creating"
I1025 12:38:47.970698       1 pool_controller.go:339]  "msg"="Runner is in state that does not allow deletion" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="1074cdab-e432-4664-8074-563356488d2d" "runner"="int-road-runner-mario-h5DB1PfJ94yu" "state"="creating"
I1025 12:38:47.970723       1 pool_controller.go:343]  "msg"="Not all runners could be deleted or are still in deleting phase, reconcile in 1 minute again." "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="1074cdab-e432-4664-8074-563356488d2d"
``` 

## trigger the image-deletion (which should be fine as no active pool consumes the image cr (this also forces a reconciliation of the pool-CR in deletion-status:

```
I1025 12:38:50.316199       1 image_webhook.go:45] image-resource "msg"="validate delete" "name"="runner-default-mario"
I1025 12:38:50.958492       1 pool_controller.go:283]  "msg"="Deleting Pool" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "pool"="mario01" "reconcileID"="4c4a5f72-24be-4855-9dd4-091a5b01778b"
I1025 12:38:50.962199       1 pool_controller.go:339]  "msg"="Runner is in state that does not allow deletion" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="4c4a5f72-24be-4855-9dd4-091a5b01778b" "runner"="int-road-runner-mario-s4YJFIhlFpLV" "state"="creating"
I1025 12:38:50.962314       1 pool_controller.go:339]  "msg"="Runner is in state that does not allow deletion" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="4c4a5f72-24be-4855-9dd4-091a5b01778b" "runner"="int-road-runner-mario-zaynlkDkZ49N" "state"="creating"
I1025 12:38:50.962423       1 pool_controller.go:339]  "msg"="Runner is in state that does not allow deletion" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="4c4a5f72-24be-4855-9dd4-091a5b01778b" "runner"="int-road-runner-mario-DQksDNCZHxqa" "state"="creating"
I1025 12:38:50.962487       1 pool_controller.go:339]  "msg"="Runner is in state that does not allow deletion" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="4c4a5f72-24be-4855-9dd4-091a5b01778b" "runner"="int-road-runner-mario-DqjBcLf5w0dh" "state"="creating"
I1025 12:38:50.962560       1 pool_controller.go:339]  "msg"="Runner is in state that does not allow deletion" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="4c4a5f72-24be-4855-9dd4-091a5b01778b" "runner"="int-road-runner-mario-h5DB1PfJ94yu" "state"="creating"
I1025 12:38:50.962653       1 pool_controller.go:343]  "msg"="Not all runners could be deleted or are still in deleting phase, reconcile in 1 minute again." "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="4c4a5f72-24be-4855-9dd4-091a5b01778b"
I1025 12:39:48.066547       1 pool_controller.go:283]  "msg"="Deleting Pool" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "pool"="mario01" "reconcileID"="a367fb11-ac56-48d0-ba10-fe1bf271187e"
I1025 12:39:48.710119       1 pool_controller.go:343]  "msg"="Not all runners could be deleted or are still in deleting phase, reconcile in 1 minute again." "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "reconcileID"="a367fb11-ac56-48d0-ba10-fe1bf271187e"
```

## once all runners are gone, it was possible to finally delete the pool in garm-side:

```
I1025 12:40:49.360495       1 pool_controller.go:283]  "msg"="Deleting Pool" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "pool"="mario01" "reconcileID"="e8416e87-4fd3-45b9-854b-f32643d9dae2"
I1025 12:40:49.391638       1 pool_webhook.go:88] pool-resource "msg"="validate update" "name"="mario01" "namespace"="garm-infra-stage-int"
I1025 12:40:49.424379       1 pool_controller.go:361]  "msg"="Successfully deleted pool" "Pool"={"name":"mario01","namespace":"garm-infra-stage-int"} "controller"="pool" "controllerGroup"="garm-operator.mercedes-benz.com" "controllerKind"="Pool" "name"="mario01" "namespace"="garm-infra-stage-int" "pool"="mario01" "reconcileID"="e8416e87-4fd3-45b9-854b-f32643d9dae2"
```