### PR TITLE
feat: add lastSyncTime annotation to CRs

### DIFF
--- a/internal/controller/enterprise_controller.go
+++ b/internal/controller/enterprise_controller.go
@@ -62,6 +62,13 @@ func (r *EnterpriseReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
+	annotations.SetLastSyncTime(enterprise)
+	err = r.Update(ctx, enterprise)
+	if err != nil {
+		log.Error(err, "can not set annotation")
+		return ctrl.Result{}, err
+	}
+
 	enterpriseClient := garmClient.NewEnterpriseClient()
 	err = enterpriseClient.Login(garmClient.GarmScopeParams{
 		BaseURL:  r.BaseURL,

--- a/internal/controller/organization_controller.go
+++ b/internal/controller/organization_controller.go
@@ -61,6 +61,13 @@ func (r *OrganizationReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	annotations.SetLastSyncTime(organization)
+	err = r.Update(ctx, organization)
+	if err != nil {
+		log.Error(err, "can not set annotation")
+		return ctrl.Result{}, err
+	}
+
 	organizationClient := garmClient.NewOrganizationClient()
 	err = organizationClient.Login(garmClient.GarmScopeParams{
 		BaseURL:  r.BaseURL,

--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -72,8 +72,15 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
+	annotations.SetLastSyncTime(pool)
+	err := r.Update(ctx, pool)
+	if err != nil {
+		log.Error(err, "can not set annotation")
+		return ctrl.Result{}, err
+	}
+
 	poolClient := garmClient.NewPoolClient()
-	err := poolClient.Login(garmClient.GarmScopeParams{
+	err = poolClient.Login(garmClient.GarmScopeParams{
 		BaseURL:  r.BaseURL,
 		Username: r.Username,
 		Password: r.Password,

--- a/internal/controller/repository_controller.go
+++ b/internal/controller/repository_controller.go
@@ -61,6 +61,13 @@ func (r *RepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
+	annotations.SetLastSyncTime(repository)
+	err = r.Update(ctx, repository)
+	if err != nil {
+		log.Error(err, "can not set annotation")
+		return ctrl.Result{}, err
+	}
+
 	repositoryClient := garmClient.NewRepositoryClient()
 	err = repositoryClient.Login(garmClient.GarmScopeParams{
 		BaseURL:  r.BaseURL,

--- a/pkg/client/key/key.go
+++ b/pkg/client/key/key.go
@@ -10,4 +10,5 @@ const (
 	PoolFinalizerName         = groupName + "/pool"
 	RunnerFinalizerName       = groupName + "/runner"
 	PausedAnnotation          = groupName + "/paused"
+	LastSyncTimeAnnotation    = groupName + "/last-sync-time"
 )

--- a/pkg/util/annotations/helpers.go
+++ b/pkg/util/annotations/helpers.go
@@ -3,6 +3,8 @@
 package annotations
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/mercedes-benz/garm-operator/pkg/client/key"
@@ -21,4 +23,23 @@ func hasAnnotation(o metav1.Object, annotation string) bool {
 	}
 	_, ok := annotations[annotation]
 	return ok
+}
+
+func SetLastSyncTime(o metav1.Object) {
+	now := time.Now().UTC()
+	newAnnotations := appendAnnotations(o, key.LastSyncTimeAnnotation, now.Format(time.RFC3339))
+	o.SetAnnotations(newAnnotations)
+}
+
+func appendAnnotations(o metav1.Object, kayValuePair ...string) map[string]string {
+	newAnnotations := map[string]string{}
+	for k, v := range o.GetAnnotations() {
+		newAnnotations[k] = v
+	}
+	for i := 0; i < len(kayValuePair)-1; i += 2 {
+		k := kayValuePair[i]
+		v := kayValuePair[i+1]
+		newAnnotations[k] = v
+	}
+	return newAnnotations
 }


### PR DESCRIPTION
Every time  a controller attempts to reconcile a CR, the last-sync-time annotation gets updated.

![image](https://github.com/mercedes-benz/garm-operator/assets/48678421/821f2a75-d53f-412b-92bb-879a04e3150f)
