### PR TITLE
chore: remove nodejs from build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,6 @@ jobs:
 
       - name: make lint
         run: make golangci-lint && GOLANGCI_LINT_EXTRA_ARGS=--timeout=1h make lint
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
       
       - name: make test
         run: make test


### PR DESCRIPTION
as we do the PR title validation in a dedicated action, we can get rid of this orphaned nodejs setup step during build