### PR TITLE
feat: generate SBOM via kubernetes-sigs/bom

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,11 @@ jobs:
       
       - name: make test
         run: make test
+
+      - name: make sbom
+        run: make sbom
+
+      - uses: actions/upload-artifact@v3
+        with:
+         name: sbom 
+         path: tmp/garm-operator.bom.spdx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
       #     BLACKDUCK_PROJECT_NAME: ${{ secrets.BLACKDUCK_PROJECT_NAME }}
       #     BLACKDUCK_TOKEN: ${{ secrets.BLACKDUCK_TOKEN }}
 
+      - name: SBOM
+        run: make sbom
+
       - name: release
         run: make release
         env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,6 +61,7 @@ release:
     - glob: tmp/garm_operator_all.yaml
     - glob: tmp/garm_operator_crds.yaml
     - glob: tmp/garm_operator.yaml
+    - glob: tmp/garm-operator.bom.spdx
     # - glob: tmp/3RD_PARTY_LICENSES.txt
     # - glob: tmp/BlackDuck_RiskReport.pdf
   header: |


### PR DESCRIPTION
As blackduck is still not stable - let's generate the SBOM with `kubernetes-sigs/bom`