### PR TITLE
feat: expose jwt exp date as metric

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -212,6 +212,7 @@ func run() error {
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("unable to set up health check: %w", err)
 	}
+
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		return fmt.Errorf("unable to set up ready check: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cloudbase/garm-provider-common v0.1.1
 	github.com/go-openapi/runtime v0.26.2
 	github.com/go-playground/validator/v10 v10.17.0
+	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/knadh/koanf/parsers/yaml v0.1.0
 	github.com/knadh/koanf/providers/env v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEe
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -137,7 +137,7 @@ func newGarmClient(garmParams GarmScopeParams) (*garm.GarmAPI, runtime.ClientAut
 	}
 
 	// update token from login response
-	extractJWTTokenExp(resp.Payload.Token)
+	extractJWTTokenExp(context.TODO(), resp.Payload.Token)
 	authToken = openapiRuntimeClient.BearerToken(resp.Payload.Token)
 
 	return apiCli, authToken, nil
@@ -214,18 +214,20 @@ func EnsureAuth[T interface{}](f Func[T]) (T, error) {
 	return result, err
 }
 
-func extractJWTTokenExp(tokenString string) {
-	fmt.Println("Extracting expiry date of jwt")
+func extractJWTTokenExp(ctx context.Context, tokenString string) {
+	log := log.FromContext(ctx)
+
+	log.Info("Extracting expiry date of jwt")
 	token, _, err := new(jwt.Parser).ParseUnverified(tokenString, jwt.MapClaims{})
 	if err != nil {
-		fmt.Printf("Failed parsing jwt: %s\n", err.Error())
+		log.Error(err, "failed parsing jwt")
 		return
 	}
 
 	if claims, ok := token.Claims.(jwt.MapClaims); ok {
 		if exp, ok := claims["exp"].(float64); ok {
 			expTime := time.Unix(int64(exp), 0)
-			fmt.Println(expTime)
+			log.Info(fmt.Sprintf("new token expires on " + expTime.Format(time.UnixDate)))
 			metrics.GarmJwtExpiresAt.Set(exp)
 		}
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -11,16 +11,16 @@ const (
 	metricControllerLabel = "controller"
 	metricControllerValue = "garm_operator"
 	metricNamespace       = "garm_operator"
-	garmAPI               = "api_requests"
-	garmInfo              = "info"
+	garmClient            = "client"
+	garmClientAPI         = "client_api_requests"
 )
 
 var (
 	GarmJwtExpiresAt = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metricNamespace,
-		Subsystem: garmInfo,
-		Name:      "jwt_expires_at",
-		Help:      "Expiry date of obtained garm-server JWT",
+		Subsystem: garmClient,
+		Name:      "jwt_expiration_timestamp_seconds",
+		Help:      "The date after which the obtained JWT expires. Expressed as a Unix Epoch Time",
 		ConstLabels: prometheus.Labels{
 			metricControllerLabel: metricControllerValue,
 		},
@@ -29,7 +29,7 @@ var (
 	TotalGarmCalls = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricNamespace,
-			Subsystem: garmAPI,
+			Subsystem: garmClientAPI,
 			Name:      "total",
 			Help:      "Total number of GARM API calls",
 			ConstLabels: prometheus.Labels{
@@ -40,7 +40,7 @@ var (
 	GarmCallErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricNamespace,
-			Subsystem: garmAPI,
+			Subsystem: garmClientAPI,
 			Name:      "errors_total",
 			Help:      "Number of GARM API calls that failed",
 			ConstLabels: prometheus.Labels{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -12,9 +12,20 @@ const (
 	metricControllerValue = "garm_operator"
 	metricNamespace       = "garm_operator"
 	garmAPI               = "api_requests"
+	garmInfo              = "info"
 )
 
 var (
+	GarmJwtExpiresAt = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricNamespace,
+		Subsystem: garmInfo,
+		Name:      "jwt_expires_at",
+		Help:      "Expiry date of obtained garm-server JWT",
+		ConstLabels: prometheus.Labels{
+			metricControllerLabel: metricControllerValue,
+		},
+	})
+
 	TotalGarmCalls = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricNamespace,
@@ -39,6 +50,7 @@ var (
 )
 
 func init() {
+	metrics.Registry.MustRegister(GarmJwtExpiresAt)
 	metrics.Registry.MustRegister(TotalGarmCalls)
 	metrics.Registry.MustRegister(GarmCallErrors)
 }


### PR DESCRIPTION
Parses jwt and exposes expiry date to prometheus like the following:

```
garm_operator_info_jwt_expires_at{controller="garm_operator"} 1.737204962e+09
```
With a grafana field override, the gauge value can be visualized like so:
![image](https://github.com/mercedes-benz/garm-operator/assets/48678421/a231b616-a614-4311-8ab9-976b3b787486)
