### PR TITLE
fix: remove frequent pool status updates

### DIFF
--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -209,9 +209,11 @@ func (r *PoolReconciler) reconcileUpdate(ctx context.Context, garmClient garmCli
 	}
 
 	// update pool idle runners count in status
-	pool.Status.LongRunningIdleRunners = uint(longRunningIdleRunnersCount)
-	if err := r.updatePoolCRStatus(ctx, pool); err != nil {
-		return ctrl.Result{}, err
+	if pool.Status.LongRunningIdleRunners != uint(longRunningIdleRunnersCount) {
+		pool.Status.LongRunningIdleRunners = uint(longRunningIdleRunnersCount)
+		if err := r.updatePoolCRStatus(ctx, pool); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	err = annotations.SetLastSyncTime(pool, r.Client)


### PR DESCRIPTION
to reduce frequent pool updates, a pool status update is only done when
the longrunningidlerunners count has changed

Signed-off-by: Mario Constanti <mario.constanti@mercedes-benz.com>