### PR TITLE
fix: remove last-sync-time annotation

### DIFF
--- a/internal/controller/enterprise_controller.go
+++ b/internal/controller/enterprise_controller.go
@@ -136,11 +136,6 @@ func (r *EnterpriseReconciler) reconcileNormal(ctx context.Context, client garmC
 		return ctrl.Result{}, err
 	}
 
-	if err = annotations.SetLastSyncTime(enterprise, r.Client); err != nil {
-		log.Error(err, fmt.Sprintf("can not set annotation: %s", key.LastSyncTimeAnnotation))
-		return ctrl.Result{}, err
-	}
-
 	log.Info("reconciling enterprise successfully done")
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/enterprise_controller_test.go
+++ b/internal/controller/enterprise_controller_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cloudbase/garm/client/enterprises"
 	"github.com/cloudbase/garm/params"
-	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +22,6 @@ import (
 	garmoperatorv1alpha1 "github.com/mercedes-benz/garm-operator/api/v1alpha1"
 	"github.com/mercedes-benz/garm-operator/pkg/client/key"
 	"github.com/mercedes-benz/garm-operator/pkg/client/mock"
-	"github.com/mercedes-benz/garm-operator/pkg/util/annotations"
 	"github.com/mercedes-benz/garm-operator/pkg/util/conditions"
 )
 
@@ -32,13 +30,12 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	tests := []struct {
-		name                         string
-		object                       runtime.Object
-		expectGarmRequest            func(m *mock.MockEnterpriseClientMockRecorder)
-		runtimeObjects               []runtime.Object
-		wantErr                      bool
-		expectedObject               *garmoperatorv1alpha1.Enterprise
-		expectLastSyncTimeAnnotation bool
+		name              string
+		object            runtime.Object
+		expectGarmRequest func(m *mock.MockEnterpriseClientMockRecorder)
+		runtimeObjects    []runtime.Object
+		wantErr           bool
+		expectedObject    *garmoperatorv1alpha1.Enterprise
 	}{
 		{
 			name: "enterprise exist - update",
@@ -137,7 +134,6 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "enterprise exist but spec has changed - update",
@@ -236,7 +232,6 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "enterprise exist but pool status has changed - update",
@@ -339,7 +334,6 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "enterprise does not exist - create and update",
@@ -445,7 +439,6 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "enterprise already exist in garm - update",
@@ -537,7 +530,6 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "enterprise does not exist in garm - create update",
@@ -644,7 +636,6 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "secret ref not found condition",
@@ -700,9 +691,8 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 					},
 				},
 			},
-			expectGarmRequest:            func(m *mock.MockEnterpriseClientMockRecorder) {},
-			expectLastSyncTimeAnnotation: false,
-			wantErr:                      true,
+			expectGarmRequest: func(m *mock.MockEnterpriseClientMockRecorder) {},
+			wantErr:           true,
 		},
 	}
 	for _, tt := range tests {
@@ -735,9 +725,6 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 				t.Errorf("EnterpriseReconciler.reconcileNormal() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-
-			// test last-sync-time
-			assert.Equal(t, tt.expectLastSyncTimeAnnotation, annotations.HasAnnotation(enterprise, key.LastSyncTimeAnnotation))
 
 			// clear out annotations to avoid comparison errors
 			enterprise.ObjectMeta.Annotations = nil

--- a/internal/controller/organization_controller.go
+++ b/internal/controller/organization_controller.go
@@ -135,11 +135,6 @@ func (r *OrganizationReconciler) reconcileNormal(ctx context.Context, client gar
 		return ctrl.Result{}, err
 	}
 
-	if err = annotations.SetLastSyncTime(organization, r.Client); err != nil {
-		log.Error(err, "can not set annotation")
-		return ctrl.Result{}, err
-	}
-
 	log.Info("reconciling organization successfully done")
 
 	return ctrl.Result{}, nil

--- a/internal/controller/organization_controller_test.go
+++ b/internal/controller/organization_controller_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cloudbase/garm/client/organizations"
 	"github.com/cloudbase/garm/params"
-	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +22,6 @@ import (
 	garmoperatorv1alpha1 "github.com/mercedes-benz/garm-operator/api/v1alpha1"
 	"github.com/mercedes-benz/garm-operator/pkg/client/key"
 	"github.com/mercedes-benz/garm-operator/pkg/client/mock"
-	"github.com/mercedes-benz/garm-operator/pkg/util/annotations"
 	"github.com/mercedes-benz/garm-operator/pkg/util/conditions"
 )
 
@@ -32,13 +30,12 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	tests := []struct {
-		name                         string
-		object                       runtime.Object
-		runtimeObjects               []runtime.Object
-		expectGarmRequest            func(m *mock.MockOrganizationClientMockRecorder)
-		wantErr                      bool
-		expectedObject               *garmoperatorv1alpha1.Organization
-		expectLastSyncTimeAnnotation bool
+		name              string
+		object            runtime.Object
+		runtimeObjects    []runtime.Object
+		expectGarmRequest func(m *mock.MockOrganizationClientMockRecorder)
+		wantErr           bool
+		expectedObject    *garmoperatorv1alpha1.Organization
 	}{
 		{
 			name: "organization exist - update",
@@ -137,7 +134,6 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "organization exist but spec has changed - update",
@@ -236,7 +232,6 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "organization exist but pool status has changed - update",
@@ -339,7 +334,6 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "organization does not exist - create and update",
@@ -445,7 +439,6 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "organization already exist in garm - update",
@@ -537,7 +530,6 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "organization does not exist in garm - create and update",
@@ -644,7 +636,6 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "secret ref not found condition",
@@ -700,9 +691,8 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 					},
 				},
 			},
-			expectGarmRequest:            func(m *mock.MockOrganizationClientMockRecorder) {},
-			expectLastSyncTimeAnnotation: false,
-			wantErr:                      true,
+			expectGarmRequest: func(m *mock.MockOrganizationClientMockRecorder) {},
+			wantErr:           true,
 		},
 	}
 	for _, tt := range tests {
@@ -735,9 +725,6 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 				t.Errorf("OrganizationReconciler.reconcileNormal() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-
-			// test last-sync-time
-			assert.Equal(t, tt.expectLastSyncTimeAnnotation, annotations.HasAnnotation(organization, key.LastSyncTimeAnnotation))
 
 			// clear out annotations to avoid comparison errors
 			organization.ObjectMeta.Annotations = nil

--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -326,16 +326,9 @@ func (r *PoolReconciler) handleUpdateError(ctx context.Context, pool *garmoperat
 }
 
 func (r *PoolReconciler) handleSuccessfulUpdate(ctx context.Context, pool *garmoperatorv1alpha1.Pool) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
-
 	conditions.MarkTrue(pool, conditions.ReadyCondition, conditions.SuccessfulReconcileReason, "")
 
 	if err := r.updatePoolCRStatus(ctx, pool); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if err := annotations.SetLastSyncTime(pool, r.Client); err != nil {
-		log.Error(err, "can not set annotation")
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/repository_controller.go
+++ b/internal/controller/repository_controller.go
@@ -135,11 +135,6 @@ func (r *RepositoryReconciler) reconcileNormal(ctx context.Context, client garmC
 		return ctrl.Result{}, err
 	}
 
-	if err = annotations.SetLastSyncTime(repository, r.Client); err != nil {
-		log.Error(err, "can not set annotation")
-		return ctrl.Result{}, err
-	}
-
 	log.Info("reconciling repository successfully done")
 
 	return ctrl.Result{}, nil

--- a/internal/controller/repository_controller_test.go
+++ b/internal/controller/repository_controller_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cloudbase/garm/client/repositories"
 	"github.com/cloudbase/garm/params"
-	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +22,6 @@ import (
 	garmoperatorv1alpha1 "github.com/mercedes-benz/garm-operator/api/v1alpha1"
 	"github.com/mercedes-benz/garm-operator/pkg/client/key"
 	"github.com/mercedes-benz/garm-operator/pkg/client/mock"
-	"github.com/mercedes-benz/garm-operator/pkg/util/annotations"
 	"github.com/mercedes-benz/garm-operator/pkg/util/conditions"
 )
 
@@ -32,13 +30,12 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	tests := []struct {
-		name                         string
-		object                       runtime.Object
-		runtimeObjects               []runtime.Object
-		expectGarmRequest            func(m *mock.MockRepositoryClientMockRecorder)
-		wantErr                      bool
-		expectedObject               *garmoperatorv1alpha1.Repository
-		expectLastSyncTimeAnnotation bool
+		name              string
+		object            runtime.Object
+		runtimeObjects    []runtime.Object
+		expectGarmRequest func(m *mock.MockRepositoryClientMockRecorder)
+		wantErr           bool
+		expectedObject    *garmoperatorv1alpha1.Repository
 	}{
 		{
 			name: "repository exist - update",
@@ -141,7 +138,6 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "repository exist but spec has changed - update",
@@ -244,7 +240,6 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "repository exist but pool status has changed - update",
@@ -351,7 +346,6 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "repository does not exist - create and update",
@@ -463,7 +457,6 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "repository already exist in garm - update",
@@ -559,7 +552,6 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 		{
 			name: "repository does not exist in garm - create and update",
@@ -671,7 +663,6 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 					},
 				}, nil)
 			},
-			expectLastSyncTimeAnnotation: true,
 		},
 	}
 	for _, tt := range tests {
@@ -704,9 +695,6 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 				t.Errorf("RepositoryReconciler.reconcileNormal() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-
-			// test last-sync-time
-			assert.Equal(t, tt.expectLastSyncTimeAnnotation, annotations.HasAnnotation(repository, key.LastSyncTimeAnnotation))
 
 			// clear out annotations to avoid comparison errors
 			repository.ObjectMeta.Annotations = nil

--- a/internal/controller/runner_controller.go
+++ b/internal/controller/runner_controller.go
@@ -31,7 +31,6 @@ import (
 	"github.com/mercedes-benz/garm-operator/pkg/config"
 	"github.com/mercedes-benz/garm-operator/pkg/filter"
 	instancefilter "github.com/mercedes-benz/garm-operator/pkg/filter/instance"
-	"github.com/mercedes-benz/garm-operator/pkg/util/annotations"
 )
 
 // RunnerReconciler reconciles a Runner object
@@ -187,11 +186,6 @@ func (r *RunnerReconciler) updateRunnerStatus(ctx context.Context, runner *garmo
 
 	if err := r.Status().Update(ctx, runner); err != nil {
 		log.Error(err, "unable to update Runner status")
-		return ctrl.Result{}, err
-	}
-
-	if err = annotations.SetLastSyncTime(runner, r.Client); err != nil {
-		log.Error(err, "can not set annotation")
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/runner_controller_test.go
+++ b/internal/controller/runner_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/mercedes-benz/garm-operator/pkg/client/key"
 	"github.com/mercedes-benz/garm-operator/pkg/client/mock"
 	"github.com/mercedes-benz/garm-operator/pkg/config"
-	"github.com/mercedes-benz/garm-operator/pkg/util/annotations"
 )
 
 func TestRunnerReconciler_reconcileCreate(t *testing.T) {
@@ -133,9 +132,6 @@ func TestRunnerReconciler_reconcileCreate(t *testing.T) {
 				t.Errorf("RunnerReconciler.reconcile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-
-			// test last-sync-time
-			assert.Equal(t, annotations.HasAnnotation(runner, key.LastSyncTimeAnnotation), true)
 
 			// clear out annotations to avoid comparison errors
 			runner.ObjectMeta.Annotations = nil

--- a/pkg/util/annotations/helpers.go
+++ b/pkg/util/annotations/helpers.go
@@ -3,11 +3,7 @@
 package annotations
 
 import (
-	"context"
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/mercedes-benz/garm-operator/pkg/client/key"
 )
@@ -25,24 +21,4 @@ func HasAnnotation(o metav1.Object, annotation string) bool {
 	}
 	_, ok := annotations[annotation]
 	return ok
-}
-
-func SetLastSyncTime(o client.Object, client client.Client) error {
-	now := time.Now().UTC()
-	newAnnotations := appendAnnotations(o, key.LastSyncTimeAnnotation, now.Format(time.RFC3339))
-	o.SetAnnotations(newAnnotations)
-	return client.Update(context.Background(), o)
-}
-
-func appendAnnotations(o metav1.Object, kayValuePair ...string) map[string]string {
-	newAnnotations := map[string]string{}
-	for k, v := range o.GetAnnotations() {
-		newAnnotations[k] = v
-	}
-	for i := 0; i < len(kayValuePair)-1; i += 2 {
-		k := kayValuePair[i]
-		v := kayValuePair[i+1]
-		newAnnotations[k] = v
-	}
-	return newAnnotations
 }


### PR DESCRIPTION
removes last-sync-time annotation which should prevent countless unnecessary reconciles to be triggered.