### PR TITLE
chore: disable automatic k8s.io package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,20 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore k8s, controller-runtime and its transitives modules as they are upgraded manually.
+      # we also have to update local kind cluster configuration (hack/kind-with-registry.sh)
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "k8s.io/*"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ SLICE ?= $(LOCALBIN)/kubectl-slice
 NANCY ?= $(LOCALBIN)/nancy
 GOVULNCHECK ?= $(LOCALBIN)/govulncheck
 KBOM ?= $(LOCALBIN)/bom
+KIND ?= $(LOCALBIN)/kind
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.0.1
@@ -182,6 +183,7 @@ MDTOC_VERSION ?= v1.1.0
 SLICE_VERSION ?= v1.2.6
 NANCY_VERSION ?= v1.0.42
 KBOM_VERSION ?= v0.5.1
+KIND_VERSION ?= v0.22.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
@@ -246,10 +248,16 @@ $(GOVULNCHECK): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install golang.org/x/vuln/cmd/govulncheck@latest
 
 .PHONY: kbom
-kbom: $(KBOM) ## Download nancy locally if necessary. If wrong version is installed, it will be overwritten.
+kbom: $(KBOM) ## Download kbom locally if necessary. If wrong version is installed, it will be overwritten.
 $(KBOM): $(LOCALBIN)
 	test -s $(LOCALBIN)/bom && $(LOCALBIN)/bom version | grep -q $(KBOM_VERSION) || \
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/bom/cmd/bom@$(KBOM_VERSION)
+
+.PHONY: kind
+kind: $(KIND) ## Download kind locally if necessary. If wrong version is installed, it will be overwritten.
+$(KIND): $(LOCALBIN)
+	test -s $(LOCALBIN)/kind && $(LOCALBIN)/kind version | grep -q $(KIND_VERSION) || \
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kind@$(KIND_VERSION)
 
 ##@ Lint / Verify
 .PHONY: lint


### PR DESCRIPTION
as there are few more things to do when updating
k8s.io/controller-runtime (e.g. using the same version in kind cluster - relevant when we start with integration tests) we will disable the dump dependabot update PRs