### PR TITLE
feat: block the creation of github.com endpoint

### DIFF
--- a/api/v1beta1/githubendpoint_types.go
+++ b/api/v1beta1/githubendpoint_types.go
@@ -31,6 +31,7 @@ type GitHubEndpointStatus struct {
 //+kubebuilder:printcolumn:name="Error",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].message",priority=1
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of GitHubEndpoint"
 
+// +kubebuilder:validation:XValidation:rule="self.metadata.name != 'github.com'",message="github.com is not allowed as name as GARM ships with a default github.com configuration."
 // GitHubEndpoint is the Schema for the githubendpoints API
 type GitHubEndpoint struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/garm-operator.mercedes-benz.com_githubendpoints.yaml
+++ b/config/crd/bases/garm-operator.mercedes-benz.com_githubendpoints.yaml
@@ -146,6 +146,10 @@ spec:
                 type: array
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: github.com is not allowed as name as GARM ships with a default
+            github.com configuration.
+          rule: self.metadata.name != 'github.com'
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
it's not possible to create a githubendpoint configuration with the name github.com

This is because garm ships a default githubendpoint configuration which is immutable.

fixes #187 