### PR TITLE
feat: error early if min. supported version match

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/mock v0.5.0
+	golang.org/x/mod v0.18.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.29.9
 	k8s.io/apimachinery v0.29.9

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfU
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
+golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+package version
+
+import "golang.org/x/mod/semver"
+
+const MinVersion = "v0.1.5"
+
+func EnsureMinimalVersion(version string) bool {
+	return semver.Compare(version, MinVersion) >= 0
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+package version
+
+import "testing"
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		isValid bool
+	}{
+		{
+			name:    "is equal",
+			version: "v0.1.5",
+			isValid: true,
+		},
+		{
+			name:    "garm is newer",
+			version: "v0.1.6",
+			isValid: true,
+		},
+		{
+			name:    "garm version to old",
+			version: "v0.1.4",
+			isValid: false,
+		},
+		{
+			name:    "garm is based on custom build without using build tags",
+			version: "v0.0.0-unknown.",
+			isValid: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EnsureMinimalVersion(tt.version); got != tt.isValid {
+				t.Errorf("Compare() = %v, want %v", got, tt.isValid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #170 

the version string get's extracted from the controller-info endpoint. And to make use of this endpoint, the garm server doesn't need to be initialized.