### PR TITLE
fix: add missing githubcredentials plural occurences

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -37,7 +37,7 @@ k8s_resource(
         'runners.garm-operator.mercedes-benz.com:customresourcedefinition',
         'repositories.garm-operator.mercedes-benz.com:customresourcedefinition',
         'garmserverconfigs.garm-operator.mercedes-benz.com:customresourcedefinition',
-        'githubcredential.garm-operator.mercedes-benz.com:customresourcedefinition',
+        'githubcredentials.garm-operator.mercedes-benz.com:customresourcedefinition',
         'githubendpoints.garm-operator.mercedes-benz.com:customresourcedefinition',
         'garm-operator-controller-manager:serviceaccount',
         'garm-operator-leader-election-role:role',

--- a/api/v1beta1/garmserverconfig_types.go
+++ b/api/v1beta1/garmserverconfig_types.go
@@ -27,7 +27,7 @@ type GarmServerConfigStatus struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:resource:path=garmserverconfigs,scope=Namespaced,categories=garm,shortName=server
+//+kubebuilder:resource:path=garmserverconfigs,scope=Namespaced,categories=garm
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion
 //+kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.controllerId",description="Controller ID"

--- a/api/v1beta1/githubcredentials_types.go
+++ b/api/v1beta1/githubcredentials_types.go
@@ -38,7 +38,7 @@ type GitHubCredentialStatus struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:resource:path=githubcredentials,scope=Namespaced,categories=garm,shortName=creds
+//+kubebuilder:resource:path=githubcredentials,scope=Namespaced,categories=garm
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion
 //+kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Credentials ID"

--- a/api/v1beta1/githubendpoint_types.go
+++ b/api/v1beta1/githubendpoint_types.go
@@ -21,7 +21,7 @@ type GitHubEndpointStatus struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:resource:path=githubendpoints,scope=Namespaced,categories=garm,shortName=gep
+//+kubebuilder:resource:path=githubendpoints,scope=Namespaced,categories=garm
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion
 //+kubebuilder:printcolumn:name="URL",type="string",JSONPath=".spec.apiBaseUrl",description="API Base URL"

--- a/config/crd/bases/garm-operator.mercedes-benz.com_garmserverconfigs.yaml
+++ b/config/crd/bases/garm-operator.mercedes-benz.com_garmserverconfigs.yaml
@@ -13,8 +13,6 @@ spec:
     kind: GarmServerConfig
     listKind: GarmServerConfigList
     plural: garmserverconfigs
-    shortNames:
-    - server
     singular: garmserverconfig
   scope: Namespaced
   versions:

--- a/config/crd/bases/garm-operator.mercedes-benz.com_githubcredentials.yaml
+++ b/config/crd/bases/garm-operator.mercedes-benz.com_githubcredentials.yaml
@@ -13,8 +13,6 @@ spec:
     kind: GitHubCredential
     listKind: GitHubCredentialList
     plural: githubcredentials
-    shortNames:
-    - creds
     singular: githubcredential
   scope: Namespaced
   versions:

--- a/config/crd/bases/garm-operator.mercedes-benz.com_githubendpoints.yaml
+++ b/config/crd/bases/garm-operator.mercedes-benz.com_githubendpoints.yaml
@@ -13,8 +13,6 @@ spec:
     kind: GitHubEndpoint
     listKind: GitHubEndpointList
     plural: githubendpoints
-    shortNames:
-    - gep
     singular: githubendpoint
   scope: Namespaced
   versions:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
   - bases/garm-operator.mercedes-benz.com_runners.yaml
   - bases/garm-operator.mercedes-benz.com_garmserverconfigs.yaml
   - bases/garm-operator.mercedes-benz.com_githubendpoints.yaml
-  - bases/garm-operator.mercedes-benz.com_githubcredential.yaml
+  - bases/garm-operator.mercedes-benz.com_githubcredentials.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/crd/patches/cainjection_in_githubcredentials.yaml
+++ b/config/crd/patches/cainjection_in_githubcredentials.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
-  name: githubcredential.garm-operator.mercedes-benz.com
+  name: githubcredentials.garm-operator.mercedes-benz.com

--- a/config/crd/patches/webhook_in_githubcredentials.yaml
+++ b/config/crd/patches/webhook_in_githubcredentials.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: githubcredential.garm-operator.mercedes-benz.com
+  name: githubcredentials.garm-operator.mercedes-benz.com
 spec:
   conversion:
     strategy: Webhook

--- a/config/rbac/githubcredentials_editor_role.yaml
+++ b/config/rbac/githubcredentials_editor_role.yaml
@@ -14,7 +14,7 @@ rules:
   - apiGroups:
       - garm-operator.mercedes-benz.com
     resources:
-      - githubcredential
+      - githubcredentials
     verbs:
       - create
       - delete
@@ -26,6 +26,6 @@ rules:
   - apiGroups:
       - garm-operator.mercedes-benz.com
     resources:
-      - githubcredential/status
+      - githubcredentials/status
     verbs:
       - get

--- a/config/rbac/githubcredentials_viewer_role.yaml
+++ b/config/rbac/githubcredentials_viewer_role.yaml
@@ -14,7 +14,7 @@ rules:
   - apiGroups:
       - garm-operator.mercedes-benz.com
     resources:
-      - githubcredential
+      - githubcredentials
     verbs:
       - get
       - list
@@ -22,6 +22,6 @@ rules:
   - apiGroups:
       - garm-operator.mercedes-benz.com
     resources:
-      - githubcredential/status
+      - githubcredentials/status
     verbs:
       - get


### PR DESCRIPTION
this pr will fix a few missing `githubcredentials` (plural) occurences.
It also drops short names for `garmserverconfig` (which was `server`), `githubcredentials` (which was `creds`) and `githubendpoints` (which was `gep`).