### PR TITLE
feat: mark v1alpha1 as deprecated

### DIFF
--- a/api/v1alpha1/enterprise_types.go
+++ b/api/v1alpha1/enterprise_types.go
@@ -24,6 +24,7 @@ type EnterpriseStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:path=enterprises,scope=Namespaced,categories=garm,shortName=ent
+//+kubebuilder:deprecatedversion:warning=This version is deprecated. Use v1beta1 instead.
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Enterprise ID"
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"

--- a/api/v1alpha1/image_types.go
+++ b/api/v1alpha1/image_types.go
@@ -31,6 +31,7 @@ type ImageStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:path=images,scope=Namespaced,categories=garm
+//+kubebuilder:deprecatedversion:warning=This version is deprecated. Use v1beta1 instead.
 //+kubebuilder:printcolumn:name="Tag",type=string,JSONPath=`.spec.tag`
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 

--- a/api/v1alpha1/organization_types.go
+++ b/api/v1alpha1/organization_types.go
@@ -24,6 +24,7 @@ type OrganizationStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:path=organizations,scope=Namespaced,categories=garm,shortName=org
+//+kubebuilder:deprecatedversion:warning=This version is deprecated. Use v1beta1 instead.
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Organization ID"
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"

--- a/api/v1alpha1/pool_types.go
+++ b/api/v1alpha1/pool_types.go
@@ -64,6 +64,7 @@ func (p *Pool) GetConditions() []metav1.Condition {
 //+kubebuilder:subresource:status
 //+kubebuilder:subresource:scale:specpath=.spec.minIdleRunners,statuspath=.status.longRunningIdleRunners,selectorpath=.status.selector
 //+kubebuilder:resource:path=pools,scope=Namespaced,categories=garm
+//+kubebuilder:deprecatedversion:warning=This version is deprecated. Use v1beta1 instead.
 //+kubebuilder:printcolumn:name="ID",type=string,JSONPath=`.status.id`
 //+kubebuilder:printcolumn:name="MinIdleRunners",type=string,JSONPath=`.spec.minIdleRunners`
 //+kubebuilder:printcolumn:name="MaxRunners",type=string,JSONPath=`.spec.maxRunners`

--- a/api/v1alpha1/repository_types.go
+++ b/api/v1alpha1/repository_types.go
@@ -25,6 +25,7 @@ type RepositoryStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:path=repositories,scope=Namespaced,categories=garm,shortName=repo
+//+kubebuilder:deprecatedversion:warning=This version is deprecated. Use v1beta1 instead.
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Repository ID"
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"

--- a/api/v1alpha1/runner_types.go
+++ b/api/v1alpha1/runner_types.go
@@ -76,6 +76,7 @@ type RunnerStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:path=runners,scope=Namespaced,categories=garm,shortName=run
+//+kubebuilder:deprecatedversion:warning=This version is deprecated. Use v1beta1 instead.
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Runner ID"
 //+kubebuilder:printcolumn:name="Pool",type="string",JSONPath=".status.poolId",description="Pool CR Name"

--- a/config/crd/bases/garm-operator.mercedes-benz.com_enterprises.yaml
+++ b/config/crd/bases/garm-operator.mercedes-benz.com_enterprises.yaml
@@ -38,6 +38,8 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/garm-operator.mercedes-benz.com_images.yaml
+++ b/config/crd/bases/garm-operator.mercedes-benz.com_images.yaml
@@ -23,6 +23,8 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/garm-operator.mercedes-benz.com_organizations.yaml
+++ b/config/crd/bases/garm-operator.mercedes-benz.com_organizations.yaml
@@ -38,6 +38,8 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/garm-operator.mercedes-benz.com_pools.yaml
+++ b/config/crd/bases/garm-operator.mercedes-benz.com_pools.yaml
@@ -60,6 +60,8 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/garm-operator.mercedes-benz.com_repositories.yaml
+++ b/config/crd/bases/garm-operator.mercedes-benz.com_repositories.yaml
@@ -38,6 +38,8 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/garm-operator.mercedes-benz.com_runners.yaml
+++ b/config/crd/bases/garm-operator.mercedes-benz.com_runners.yaml
@@ -48,6 +48,8 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
We will mark `v1alpha1` as deprecated.

```bash
kubectl apply -f tmp/flux-dev-pool.yaml 
Warning: This version is deprecated. Use v1beta1 instead.
pool.garm-operator.mercedes-benz.com/flux created
```

![image](https://github.com/user-attachments/assets/aae41e4a-38e5-487f-a783-e1bd826fa88f)


Signed-off-by: Mario Constanti <mario.constanti@mercedes-benz.com>