### PR TITLE
fix: apply a dummy default controller config

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -189,7 +190,7 @@ func IsUnauthenticatedError(err interface{}) bool {
 	if !ok {
 		return false
 	}
-	return apiErr.IsCode(401)
+	return apiErr.IsCode(http.StatusUnauthorized)
 }
 
 func IsNotFoundError(err interface{}) bool {
@@ -197,7 +198,15 @@ func IsNotFoundError(err interface{}) bool {
 	if !ok {
 		return false
 	}
-	return apiErr.IsCode(404)
+	return apiErr.IsCode(http.StatusNotFound)
+}
+
+func IsConflictError(err interface{}) bool {
+	apiErr, ok := err.(runtime.ClientResponseStatus)
+	if !ok {
+		return false
+	}
+	return apiErr.IsCode(http.StatusConflict)
 }
 
 type Func[T interface{}] func() (T, error)

--- a/pkg/client/controller.go
+++ b/pkg/client/controller.go
@@ -3,9 +3,12 @@ package client
 
 import (
 	"github.com/cloudbase/garm/client/controller"
+	garmcontroller "github.com/cloudbase/garm/client/controller"
 	"github.com/cloudbase/garm/client/controller_info"
+	"github.com/cloudbase/garm/params"
 
 	"github.com/mercedes-benz/garm-operator/pkg/metrics"
+	"github.com/mercedes-benz/garm-operator/pkg/util"
 )
 
 type ControllerClient interface {
@@ -23,12 +26,33 @@ func NewControllerClient() ControllerClient {
 	}
 }
 
+const (
+	initialMetadataURL = "https://initial.metadata.garm.local"
+	initialCallbackURL = "https://initial.callback.garm.local"
+	initialWebhookURL  = "https://initial.webhook.garm.local"
+)
+
 func (s *controllerClient) GetControllerInfo() (*controller_info.ControllerInfoOK, error) {
 	return EnsureAuth(func() (*controller_info.ControllerInfoOK, error) {
 		metrics.TotalGarmCalls.WithLabelValues("controller.Info").Inc()
 		controllerInfo, err := s.GarmAPI().ControllerInfo.ControllerInfo(&controller_info.ControllerInfoParams{}, s.Token())
 		if err != nil {
 			metrics.GarmCallErrors.WithLabelValues("controller.Info").Inc()
+
+			// after the first run, garm needs a configuration for webhook, metadata and callback
+			// to make garm work after the first run, we set some defaults
+			if IsConflictError(err) {
+				updateParams := garmcontroller.NewUpdateControllerParams().WithBody(params.UpdateControllerParams{
+					MetadataURL: util.StringPtr(initialMetadataURL),
+					CallbackURL: util.StringPtr(initialCallbackURL),
+					WebhookURL:  util.StringPtr(initialWebhookURL),
+				})
+				// let's initiate the new controller with some defaults
+				_, err := s.UpdateController(updateParams)
+				if err != nil {
+					return nil, err
+				}
+			}
 			return nil, err
 		}
 		return controllerInfo, nil


### PR DESCRIPTION
to make garm work after the initialization, we apply a default config for webhookURL, metadataURL and callbackURL

this config will be overwritten once a garmserverconfig CR got applied

during the initial start of garm with the operator, the `controller info` will look like:

```bash
+-------------------------+-------------------------------------------------------------------------+
| FIELD                   | VALUE                                                                   |
+-------------------------+-------------------------------------------------------------------------+
| Controller ID           | dd2524b9-0789-499d-ba7d-3dba65cf9d3f                                    |
| Hostname                | garm-server-7c9d8f57b6-54zt2                                            |
| Metadata URL            | https://initial.metadata.garm.cloud                                     |
| Callback URL            | https://initial.callback.garm.cloud                                     |
| Webhook Base URL        | https://initial.webhook.garm.cloud                                      |
| Controller Webhook URL  | https://initial.webhook.garm.cloud/dd2524b9-0789-499d-ba7d-3dba65cf9d3f |
| Minimum Job Age Backoff | 30                                                                      |
| Version                 | v0.1.5                                                                  |
+-------------------------+-------------------------------------------------------------------------+
```

after a corresponding `garmserverconfig` CR gets applied, the `controller info` will look like:

```bash
garm-cli-v0.1.5 controller show
+-------------------------+---------------------------------------------------------------------------------------------+
| FIELD                   | VALUE                                                                                       |
+-------------------------+---------------------------------------------------------------------------------------------+
| Controller ID           | dd2524b9-0789-499d-ba7d-3dba65cf9d3f                                                        |
| Hostname                | garm-server-7c9d8f57b6-54zt2                                                                |
| Metadata URL            | http://garm-server.garm-server.svc:9997/api/v1/metadata                                     |
| Callback URL            | http://garm-server.garm-server.svc:9997/api/v1/callbacks                                    |
| Webhook Base URL        | http://garm-server.garm-server.svc:9997/api/v1/webhook                                      |
| Controller Webhook URL  | http://garm-server.garm-server.svc:9997/api/v1/webhook/dd2524b9-0789-499d-ba7d-3dba65cf9d3f |
| Minimum Job Age Backoff | 30                                                                                          |
| Version                 | v0.1.5                                                                                      |
+-------------------------+---------------------------------------------------------------------------------------------+
```