### PR TITLE
fix: dublicate pool creation

### DIFF
--- a/config/samples/garm-operator_v1beta1_pool.yaml
+++ b/config/samples/garm-operator_v1beta1_pool.yaml
@@ -1,4 +1,4 @@
-apiVersion: garm-operator.mercedes-benz.com/v1alpha1
+apiVersion: garm-operator.mercedes-benz.com/v1beta1
 kind: Pool
 metadata:
   name: openstack-small-pool-enterprise
@@ -22,7 +22,7 @@ spec:
   tags:
     - linux-amd64-ubuntu
 ---
-apiVersion: garm-operator.mercedes-benz.com/v1alpha1
+apiVersion: garm-operator.mercedes-benz.com/v1beta1
 kind: Pool
 metadata:
   name: openstack-medium-pool-org
@@ -46,7 +46,7 @@ spec:
   tags:
     - linux-amd64-ubuntu
 ---
-apiVersion: garm-operator.mercedes-benz.com/v1alpha1
+apiVersion: garm-operator.mercedes-benz.com/v1beta1
 kind: Pool
 metadata:
   name: openstack-medium-pool-repo

--- a/config/samples/garm-operator_v1beta1_repository.yaml
+++ b/config/samples/garm-operator_v1beta1_repository.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   webhookSecretRef:
     key: "webhookSecret"
-    name: "org-webhook-secret"
+    name: "repo-webhook-secret"
   credentialsRef:
     apiGroup: garm-operator.mercedes-benz.com
     kind: GitHubCredentials

--- a/internal/controller/enterprise_controller_test.go
+++ b/internal/controller/enterprise_controller_test.go
@@ -431,6 +431,9 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "new-enterprise",
 					Namespace: "default",
+					Finalizers: []string{
+						key.EnterpriseFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.EnterpriseSpec{
 					CredentialsRef: corev1.TypedLocalObjectReference{
@@ -566,6 +569,9 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "new-enterprise",
 					Namespace: "default",
+					Finalizers: []string{
+						key.EnterpriseFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.EnterpriseSpec{
 					CredentialsRef: corev1.TypedLocalObjectReference{

--- a/internal/controller/githubcredentials_controller_test.go
+++ b/internal/controller/githubcredentials_controller_test.go
@@ -387,6 +387,9 @@ func TestGitHubCredentialReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "new-github-credential",
 					Namespace: "default",
+					Finalizers: []string{
+						key.CredentialsFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.GitHubCredentialSpec{
 					Description: "new-github-credential",
@@ -582,6 +585,9 @@ func TestGitHubCredentialReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "existing-github-credential",
 					Namespace: "default",
+					Finalizers: []string{
+						key.CredentialsFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.GitHubCredentialSpec{
 					Description: "existing-github-credential",

--- a/internal/controller/githubendpoint_controller_test.go
+++ b/internal/controller/githubendpoint_controller_test.go
@@ -266,6 +266,9 @@ func TestGitHubEndpointReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "new-github-endpoint",
 					Namespace: "default",
+					Finalizers: []string{
+						key.GitHubEndpointFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.GitHubEndpointSpec{
 					Description:   "new github endpoint",
@@ -375,6 +378,9 @@ func TestGitHubEndpointReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "existing-github-endpoint",
 					Namespace: "default",
+					Finalizers: []string{
+						key.GitHubEndpointFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.GitHubEndpointSpec{
 					Description:   "",
@@ -436,6 +442,9 @@ func TestGitHubEndpointReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "existing-github-endpoint",
 					Namespace: "default",
+					Finalizers: []string{
+						key.GitHubEndpointFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.GitHubEndpointSpec{
 					Description:   "existing-github-endpoint",
@@ -495,6 +504,9 @@ func TestGitHubEndpointReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "existing-github-endpoint",
 					Namespace: "default",
+					Finalizers: []string{
+						key.GitHubEndpointFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.GitHubEndpointSpec{
 					Description:   "existing-github-endpoint",

--- a/internal/controller/organization_controller_test.go
+++ b/internal/controller/organization_controller_test.go
@@ -431,6 +431,9 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "new-organization",
 					Namespace: "default",
+					Finalizers: []string{
+						key.OrganizationFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.OrganizationSpec{
 					CredentialsRef: corev1.TypedLocalObjectReference{
@@ -566,6 +569,9 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "new-organization",
 					Namespace: "default",
+					Finalizers: []string{
+						key.OrganizationFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.OrganizationSpec{
 					CredentialsRef: corev1.TypedLocalObjectReference{

--- a/internal/controller/pool_controller_test.go
+++ b/internal/controller/pool_controller_test.go
@@ -63,6 +63,9 @@ func TestPoolController_ReconcileCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-enterprise-pool",
 					Namespace: namespaceName,
+					Finalizers: []string{
+						key.PoolFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.PoolSpec{
 					GitHubScopeRef: corev1.TypedLocalObjectReference{
@@ -132,6 +135,13 @@ func TestPoolController_ReconcileCreate(t *testing.T) {
 							Status:             metav1.ConditionTrue,
 							Message:            "Successfully fetched Image CR Ref",
 							Reason:             string(conditions.FetchingImageRefSuccessReason),
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+						{
+							Type:               string(conditions.ScopeReference),
+							Status:             metav1.ConditionTrue,
+							Message:            "Successfully fetched Enterprise CR Ref",
+							Reason:             string(conditions.FetchingScopeRefSuccessReason),
 							LastTransitionTime: metav1.NewTime(time.Now()),
 						},
 					},
@@ -271,6 +281,9 @@ func TestPoolController_ReconcileCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-enterprise-pool",
 					Namespace: namespaceName,
+					Finalizers: []string{
+						key.PoolFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.PoolSpec{
 					GitHubScopeRef: corev1.TypedLocalObjectReference{
@@ -341,6 +354,13 @@ func TestPoolController_ReconcileCreate(t *testing.T) {
 							Status:             metav1.ConditionTrue,
 							Message:            "Successfully fetched Image CR Ref",
 							Reason:             string(conditions.FetchingImageRefSuccessReason),
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+						{
+							Type:               string(conditions.ScopeReference),
+							Status:             metav1.ConditionTrue,
+							Message:            "Successfully fetched Enterprise CR Ref",
+							Reason:             string(conditions.FetchingScopeRefSuccessReason),
 							LastTransitionTime: metav1.NewTime(time.Now()),
 						},
 					},
@@ -559,6 +579,9 @@ func TestPoolController_ReconcileCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-enterprise-pool",
 					Namespace: namespaceName,
+					Finalizers: []string{
+						key.PoolFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.PoolSpec{
 					GitHubScopeRef: corev1.TypedLocalObjectReference{
@@ -631,6 +654,13 @@ func TestPoolController_ReconcileCreate(t *testing.T) {
 							Status:             metav1.ConditionTrue,
 							Message:            "Successfully fetched Image CR Ref",
 							Reason:             string(conditions.FetchingImageRefSuccessReason),
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+						{
+							Type:               string(conditions.ScopeReference),
+							Status:             metav1.ConditionTrue,
+							Message:            "Successfully fetched Enterprise CR Ref",
+							Reason:             string(conditions.FetchingScopeRefSuccessReason),
 							LastTransitionTime: metav1.NewTime(time.Now()),
 						},
 					},
@@ -959,6 +989,9 @@ func TestPoolController_ReconcileCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-enterprise-pool",
 					Namespace: namespaceName,
+					Finalizers: []string{
+						key.PoolFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.PoolSpec{
 					GitHubScopeRef: corev1.TypedLocalObjectReference{
@@ -1030,6 +1063,13 @@ func TestPoolController_ReconcileCreate(t *testing.T) {
 							Message:            "images.garm-operator.mercedes-benz.com \"ubuntu-image\" not found",
 							LastTransitionTime: metav1.NewTime(time.Now()),
 						},
+						{
+							Type:               string(conditions.ScopeReference),
+							Status:             metav1.ConditionTrue,
+							Message:            "Successfully fetched Enterprise CR Ref",
+							Reason:             string(conditions.FetchingScopeRefSuccessReason),
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
 					},
 				},
 			},
@@ -1098,6 +1138,9 @@ func TestPoolController_ReconcileCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-enterprise-pool",
 					Namespace: namespaceName,
+					Finalizers: []string{
+						key.PoolFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.PoolSpec{
 					GitHubScopeRef: corev1.TypedLocalObjectReference{
@@ -1168,6 +1211,13 @@ func TestPoolController_ReconcileCreate(t *testing.T) {
 							Reason:             string(conditions.FetchingImageRefFailedReason),
 							Status:             metav1.ConditionFalse,
 							Message:            "images.garm-operator.mercedes-benz.com \"ubuntu-image-not-existent\" not found",
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+						{
+							Type:               string(conditions.ScopeReference),
+							Status:             metav1.ConditionTrue,
+							Message:            "Successfully fetched Enterprise CR Ref",
+							Reason:             string(conditions.FetchingScopeRefSuccessReason),
 							LastTransitionTime: metav1.NewTime(time.Now()),
 						},
 					},

--- a/internal/controller/repository_controller_test.go
+++ b/internal/controller/repository_controller_test.go
@@ -443,6 +443,9 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "new-repository",
 					Namespace: "default",
+					Finalizers: []string{
+						key.RepositoryFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.RepositorySpec{
 					CredentialsRef: corev1.TypedLocalObjectReference{
@@ -584,6 +587,9 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "new-repository",
 					Namespace: "default",
+					Finalizers: []string{
+						key.RepositoryFinalizerName,
+					},
 				},
 				Spec: garmoperatorv1beta1.RepositorySpec{
 					CredentialsRef: corev1.TypedLocalObjectReference{

--- a/pkg/client/key/key.go
+++ b/pkg/client/key/key.go
@@ -11,5 +11,6 @@ const (
 	RunnerFinalizerName         = groupName + "/runner"
 	GitHubEndpointFinalizerName = groupName + "/endpoint"
 	CredentialsFinalizerName    = groupName + "/credentials"
+	ServerConfigFinalizerName   = groupName + "/serverconfig"
 	PausedAnnotation            = groupName + "/paused"
 )

--- a/pkg/finalizers/finalizers.go
+++ b/pkg/finalizers/finalizers.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+package finalizers
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func EnsureFinalizer(ctx context.Context, c client.Client, o client.Object, finalizer string) (finalizerAdded bool, err error) {
+	// Finalizers can only be added when the deletionTimestamp is not set.
+	if !o.GetDeletionTimestamp().IsZero() {
+		return false, nil
+	}
+
+	if controllerutil.ContainsFinalizer(o, finalizer) {
+		return false, nil
+	}
+
+	controllerutil.AddFinalizer(o, finalizer)
+
+	if err := c.Update(ctx, o); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
by setting the finalizer on pool level, it's necessary to immediately end the reconciliation loop and add the pool CR back to the reconciliation loop. Otherwise the reconciliation will continue and a parallel reconciliation will happen where the pool status (with the pool id) is still empty - which leads to another pool creation