### PR TITLE
feat: allow GithubEndpoint object named github.com

### DIFF
--- a/api/v1beta1/githubendpoint_types.go
+++ b/api/v1beta1/githubendpoint_types.go
@@ -29,7 +29,6 @@ type GitHubEndpointStatus struct {
 //+kubebuilder:printcolumn:name="Error",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].message",priority=1
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of GitHubEndpoint"
 
-// +kubebuilder:validation:XValidation:rule="self.metadata.name != 'github.com'",message="github.com is not allowed as name as GARM ships with a default github.com configuration."
 // GitHubEndpoint is the Schema for the githubendpoints API
 type GitHubEndpoint struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/garm-operator.mercedes-benz.com_githubendpoints.yaml
+++ b/config/crd/bases/garm-operator.mercedes-benz.com_githubendpoints.yaml
@@ -153,10 +153,6 @@ spec:
                 type: array
             type: object
         type: object
-        x-kubernetes-validations:
-        - message: github.com is not allowed as name as GARM ships with a default
-            github.com configuration.
-          rule: self.metadata.name != 'github.com'
     served: true
     storage: true
     subresources:

--- a/docs/adrs/github_default_endpoint.md
+++ b/docs/adrs/github_default_endpoint.md
@@ -3,7 +3,7 @@
 ---
 date: 2024-11-20
 desc: Reflection of the default GitHub endpoint
-state: accepted
+state: deprecated
 ---
 <!--
 What is the status, such as proposed, accepted, rejected, deprecated, superseded, etc.?
@@ -46,3 +46,7 @@ The `GitHubEndpoint` is referenced in the `GitHubCredential` object.
 ## Decision Outcome
 
 The validation rules in the `CRD` blocks the creation of a `GitHubEndpoint` object with the name `github.com`.
+
+> ![IMPORTANT]
+> With [PR #412](https://github.com/cloudbase/garm/pull/412) `garm` allowed the mutation of the default GitHub API endpoint. This means that the `GitHubEndpoint` object with the name `github.com` can be created and updated.
+> Therefore the restriction in the `CRD` is removed and the `GitHubEndpoint` object with the name `github.com` can be created and updated.


### PR DESCRIPTION
As garm has removed the restriction for immutable github.com named github-endpoints, there is no need to keep this restriction in the operator as well.

closes #267 