### PR TITLE
fix: add credentials for OSS nancy scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
           go-version: '1.24.4'
 
       - name: make verify
+        env:
+          OSS_TOKEN: ${{ secrets.OSS_TOKEN }}
+          OSS_USERNAME: ${{ secrets.OSS_USERNAME }}
         run: make verify
 
       - name: make lint

--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ govulncheck-scan: govulncheck ## Perform govulncheck scan
 
 .PHONY: nancy-scan
 nancy-scan: nancy ## Perform nancy scan
-	go list -json -deps ./... | $(NANCY) sleuth
+	@go list -json -deps ./... | $(NANCY) sleuth --token=$(OSS_TOKEN) --username=$(OSS_USERNAME)
 
 ##@ Documentation
 .PHONY: generate-doctoc


### PR DESCRIPTION
nancy-scan now requires credentials to access OSS index. 
See: https://ossindex.sonatype.org/doc/auth-required