### PR TITLE
chore: bump golangci-lint to v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,19 +1,16 @@
 # SPDX-License-Identifier: MIT
+version: "2"
+run:
+  allow-parallel-runners: true
 linters:
-  disable-all: true
-  fast: false
+  default: none
   enable:
-    - gci
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - gofumpt
-    - goimports
     - godox
     - govet
     - gosec
-    - gosimple
     - importas
     - ineffassign
     - loggercheck
@@ -29,49 +26,50 @@ linters:
     - unused
     - wastedassign
     - whitespace
+  settings:
+    revive:
+      confidence: 0.8 # ignore missing package comments ( xref: https://github.com/golangci/golangci-lint/issues/2610 )
+    loggercheck:
+      klog: true
+      zap: false
+      require-string-key: true
+      no-printf-like: true
+    gosec:
+      excludes:
+        - G115 # Potential integer overflow when converting between integer types
+    importas:
+      no-unaliased: false
+      alias:
+        - pkg: github.com/mercedes-benz/garm-operator/api/v1alpha1
+          alias: garmoperatorv1alpha1
+        - pkg: github.com/mercedes-benz/garm-operator/api/v1beta1
+          alias: garmoperatorv1beta1
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: sigs.k8s.io/controller-runtime
+          alias: ctrl
+        - pkg: k8s.io/api/admission/v1
+          alias: admissionv1
+  exclusions:
+    rules:
+      - linters:
+          - revive
+        path: 'api/v1alpha1/(.+)_conversion\.go'
+        text: "var-naming: don't use underscores in Go names; func (.+)"
 
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/mercedes-benz/garm-operator)
-
-  goimports:
-    local-prefixes: github.com/mercedes-benz/garm-operator
-
-  importas:
-    no-unaliased: false
-    alias:
-      - pkg: github.com/mercedes-benz/garm-operator/api/v1alpha1
-        alias: garmoperatorv1alpha1
-      - pkg: github.com/mercedes-benz/garm-operator/api/v1beta1
-        alias: garmoperatorv1beta1
-      - pkg: k8s.io/api/core/v1
-        alias: corev1
-      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-        alias: metav1
-      - pkg: k8s.io/apimachinery/pkg/api/errors
-        alias: apierrors
-      - pkg: sigs.k8s.io/controller-runtime
-        alias: ctrl
-      - pkg: k8s.io/api/admission/v1
-        alias: admissionv1
-
-  loggercheck:
-    klog: true
-    zap: false
-    require-string-key: true
-    no-printf-like: true
-
-  gosec:
-    excludes:
-      - G115 # Potential integer overflow when converting between integer types
-
-issues:
-  exclude-rules:
-    # exclude revive warnings for generated code
-    - linters:
-        - revive
-      path: 'api/v1alpha1/(.+)_conversion\.go'
-      text: "var-naming: don't use underscores in Go names; func (.+)"
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/mercedes-benz/garm-operator)

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ KIND ?= $(LOCALBIN)/kind
 KUSTOMIZE_VERSION ?= v5.0.1
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
 CONVERSION_GEN_VERSION ?= v0.34.2
-GOLANGCI_LINT_VERSION ?= v1.64.2
+GOLANGCI_LINT_VERSION ?= v2.11.4
 MOCKGEN_VERSION ?= v0.4.0
 GORELEASER_VERSION ?= v1.21.0
 MDTOC_VERSION ?= v1.1.0
@@ -220,7 +220,7 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary. If wrong version is installed, it will be overwritten.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	test -s $(LOCALBIN)/golangci-lint && $(LOCALBIN)/golangci-lint --version | grep -q $(GOLANGCI_LINT_VERSION) || \
-	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: mockgen
 mockgen: $(MOCKGEN) ## Download mockgen locally if necessary. If wrong version is installed, it will be overwritten.

--- a/api/v1alpha1/enterprise_types.go
+++ b/api/v1alpha1/enterprise_types.go
@@ -76,7 +76,7 @@ func (e *Enterprise) GetID() string {
 }
 
 func (e *Enterprise) GetName() string {
-	return e.ObjectMeta.Name
+	return e.Name
 }
 
 func (e *Enterprise) GetPoolManagerIsRunning() bool {

--- a/api/v1alpha1/organization_types.go
+++ b/api/v1alpha1/organization_types.go
@@ -76,7 +76,7 @@ func (o *Organization) GetID() string {
 }
 
 func (o *Organization) GetName() string {
-	return o.ObjectMeta.Name
+	return o.Name
 }
 
 func (o *Organization) GetPoolManagerIsRunning() bool {

--- a/api/v1alpha1/repository_types.go
+++ b/api/v1alpha1/repository_types.go
@@ -77,7 +77,7 @@ func (r *Repository) GetID() string {
 }
 
 func (r *Repository) GetName() string {
-	return r.ObjectMeta.Name
+	return r.Name
 }
 
 func (r *Repository) GetPoolManagerIsRunning() bool {

--- a/api/v1beta1/enterprise_types.go
+++ b/api/v1beta1/enterprise_types.go
@@ -79,7 +79,7 @@ func (e *Enterprise) GetID() string {
 }
 
 func (e *Enterprise) GetName() string {
-	return e.ObjectMeta.Name
+	return e.Name
 }
 
 func (e *Enterprise) GetPoolManagerIsRunning() bool {

--- a/api/v1beta1/organization_types.go
+++ b/api/v1beta1/organization_types.go
@@ -79,7 +79,7 @@ func (o *Organization) GetID() string {
 }
 
 func (o *Organization) GetName() string {
-	return o.ObjectMeta.Name
+	return o.Name
 }
 
 func (o *Organization) GetPoolManagerIsRunning() bool {

--- a/api/v1beta1/repository_types.go
+++ b/api/v1beta1/repository_types.go
@@ -80,7 +80,7 @@ func (r *Repository) GetID() string {
 }
 
 func (r *Repository) GetName() string {
-	return r.ObjectMeta.Name
+	return r.Name
 }
 
 func (r *Repository) GetPoolManagerIsRunning() bool {

--- a/internal/controller/enterprise_controller_test.go
+++ b/internal/controller/enterprise_controller_test.go
@@ -143,6 +143,7 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 			},
 			expectGarmRequest: func(m *mock.MockEnterpriseClientMockRecorder) {
 				m.ListEnterprises(enterprises.NewListEnterprisesParams()).Return(&enterprises.ListEnterprisesOK{Payload: params.Enterprises{
+					//nolint:gosec
 					{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-enterprise",
@@ -152,10 +153,12 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 				}}, nil)
 				m.UpdateEnterprise(enterprises.NewUpdateEnterpriseParams().
 					WithEnterpriseID("e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&enterprises.UpdateEnterpriseOK{
+					//nolint:gosec
 					Payload: params.Enterprise{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-enterprise",
@@ -271,6 +274,7 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 			},
 			expectGarmRequest: func(m *mock.MockEnterpriseClientMockRecorder) {
 				m.ListEnterprises(enterprises.NewListEnterprisesParams()).Return(&enterprises.ListEnterprisesOK{Payload: params.Enterprises{
+					//nolint:gosec
 					{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-enterprise",
@@ -399,6 +403,7 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 			},
 			expectGarmRequest: func(m *mock.MockEnterpriseClientMockRecorder) {
 				m.ListEnterprises(enterprises.NewListEnterprisesParams()).Return(&enterprises.ListEnterprisesOK{Payload: params.Enterprises{
+					//nolint:gosec
 					{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-enterprise",
@@ -408,10 +413,12 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 				}}, nil)
 				m.UpdateEnterprise(enterprises.NewUpdateEnterpriseParams().
 					WithEnterpriseID("e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&enterprises.UpdateEnterpriseOK{
+					//nolint:gosec
 					Payload: params.Enterprise{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-enterprise",
@@ -527,6 +534,7 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 				},
 			},
 			expectGarmRequest: func(m *mock.MockEnterpriseClientMockRecorder) {
+				//nolint:gosec
 				m.ListEnterprises(enterprises.NewListEnterprisesParams()).Return(&enterprises.ListEnterprisesOK{Payload: params.Enterprises{
 					{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
@@ -536,11 +544,13 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 					},
 				}}, nil)
 				m.CreateEnterprise(enterprises.NewCreateEnterpriseParams().WithBody(
+					//nolint:gosec
 					params.CreateEnterpriseParams{
 						Name:            "new-enterprise",
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&enterprises.CreateEnterpriseOK{
+					//nolint:gosec
 					Payload: params.Enterprise{
 						ID:              "9e0da3cb-130b-428d-aa8a-e314d955060e",
 						Name:            "new-enterprise",
@@ -550,10 +560,12 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 				}, nil)
 				m.UpdateEnterprise(enterprises.NewUpdateEnterpriseParams().
 					WithEnterpriseID("9e0da3cb-130b-428d-aa8a-e314d955060e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&enterprises.UpdateEnterpriseOK{
+					//nolint:gosec
 					Payload: params.Enterprise{
 						ID:              "9e0da3cb-130b-428d-aa8a-e314d955060e",
 						Name:            "new-enterprise",
@@ -674,10 +686,12 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 				}}, nil)
 				m.UpdateEnterprise(enterprises.NewUpdateEnterpriseParams().
 					WithEnterpriseID("e1dbf9a6-a9f6-4594-a5ac-12345").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&enterprises.UpdateEnterpriseOK{
+					//nolint:gosec
 					Payload: params.Enterprise{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-12345",
 						Name:            "new-enterprise",
@@ -796,11 +810,13 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 					{},
 				}}, nil)
 				m.CreateEnterprise(enterprises.NewCreateEnterpriseParams().WithBody(
+					//nolint:gosec
 					params.CreateEnterpriseParams{
 						Name:            "existing-enterprise",
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&enterprises.CreateEnterpriseOK{
+					//nolint:gosec
 					Payload: params.Enterprise{
 						Name:            "existing-enterprise",
 						CredentialsName: "github-creds",
@@ -810,10 +826,12 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 				}, nil)
 				m.UpdateEnterprise(enterprises.NewUpdateEnterpriseParams().
 					WithEnterpriseID("9e0da3cb-130b-428d-aa8a-e314d955060e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&enterprises.UpdateEnterpriseOK{
+					//nolint:gosec
 					Payload: params.Enterprise{
 						ID:              "9e0da3cb-130b-428d-aa8a-e314d955060e",
 						Name:            "existing-enterprise",
@@ -937,10 +955,10 @@ func TestEnterpriseReconciler_reconcileNormal(t *testing.T) {
 			}
 
 			// clear out annotations to avoid comparison errors
-			enterprise.ObjectMeta.Annotations = nil
+			enterprise.Annotations = nil
 
 			// empty resource version to avoid comparison errors
-			enterprise.ObjectMeta.ResourceVersion = ""
+			enterprise.ResourceVersion = ""
 
 			// clear conditions lastTransitionTime to avoid comparison errors
 			conditions.NilLastTransitionTime(tt.expectedObject)

--- a/internal/controller/garmserverconfig_controller_test.go
+++ b/internal/controller/garmserverconfig_controller_test.go
@@ -127,10 +127,10 @@ func TestGarmServerConfig_reconcile(t *testing.T) {
 			}
 
 			// clear out annotations to avoid comparison errors
-			garmServerConfig.ObjectMeta.Annotations = nil
+			garmServerConfig.Annotations = nil
 
 			// empty resource version to avoid comparison errors
-			garmServerConfig.ObjectMeta.ResourceVersion = ""
+			garmServerConfig.ResourceVersion = ""
 
 			// clear conditions lastTransitionTime to avoid comparison errors
 			conditions.NilLastTransitionTime(tt.expectedObject)

--- a/internal/controller/githubcredentials_controller_test.go
+++ b/internal/controller/githubcredentials_controller_test.go
@@ -782,10 +782,10 @@ func TestGitHubCredentialReconciler_reconcileNormal(t *testing.T) {
 			}
 
 			// clear out annotations to avoid comparison errors
-			GitHubCredential.ObjectMeta.Annotations = nil
+			GitHubCredential.Annotations = nil
 
 			// empty resource version to avoid comparison errors
-			GitHubCredential.ObjectMeta.ResourceVersion = ""
+			GitHubCredential.ResourceVersion = ""
 
 			// clear conditions lastTransitionTime to avoid comparison errors
 			conditions.NilLastTransitionTime(tt.expectedObject)

--- a/internal/controller/githubendpoint_controller_test.go
+++ b/internal/controller/githubendpoint_controller_test.go
@@ -609,10 +609,10 @@ func TestGitHubEndpointReconciler_reconcileNormal(t *testing.T) {
 			}
 
 			// clear out annotations to avoid comparison errors
-			githubEndpoint.ObjectMeta.Annotations = nil
+			githubEndpoint.Annotations = nil
 
 			// empty resource version to avoid comparison errors
-			githubEndpoint.ObjectMeta.ResourceVersion = ""
+			githubEndpoint.ResourceVersion = ""
 
 			// clear conditions lastTransitionTime to avoid comparison errors
 			conditions.NilLastTransitionTime(tt.expectedObject)

--- a/internal/controller/organization_controller_test.go
+++ b/internal/controller/organization_controller_test.go
@@ -152,10 +152,12 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 				}}, nil)
 				m.UpdateOrganization(organizations.NewUpdateOrgParams().
 					WithOrgID("e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&organizations.UpdateOrgOK{
+					//nolint:gosec
 					Payload: params.Organization{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-organization",
@@ -398,6 +400,7 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 				},
 			},
 			expectGarmRequest: func(m *mock.MockOrganizationClientMockRecorder) {
+				//nolint:gosec
 				m.ListOrganizations(organizations.NewListOrgsParams()).Return(&organizations.ListOrgsOK{Payload: params.Organizations{
 					{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
@@ -408,10 +411,12 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 				}}, nil)
 				m.UpdateOrganization(organizations.NewUpdateOrgParams().
 					WithOrgID("e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&organizations.UpdateOrgOK{
+					//nolint:gosec
 					Payload: params.Organization{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-organization",
@@ -536,11 +541,13 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 					},
 				}}, nil)
 				m.CreateOrganization(organizations.NewCreateOrgParams().WithBody(
+					//nolint:gosec
 					params.CreateOrgParams{
 						Name:            "new-organization",
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&organizations.CreateOrgOK{
+					//nolint:gosec
 					Payload: params.Organization{
 						Name:            "new-organization",
 						CredentialsName: "github-creds",
@@ -550,10 +557,12 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 				}, nil)
 				m.UpdateOrganization(organizations.NewUpdateOrgParams().
 					WithOrgID("9e0da3cb-130b-428d-aa8a-e314d955060e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&organizations.UpdateOrgOK{
+					//nolint:gosec
 					Payload: params.Organization{
 						ID:              "9e0da3cb-130b-428d-aa8a-e314d955060e",
 						Name:            "new-organization",
@@ -674,10 +683,12 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 				}}, nil)
 				m.UpdateOrganization(organizations.NewUpdateOrgParams().
 					WithOrgID("e1dbf9a6-a9f6-4594-a5ac-12345").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&organizations.UpdateOrgOK{
+					//nolint:gosec
 					Payload: params.Organization{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-12345",
 						Name:            "new-organization",
@@ -796,11 +807,13 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 					{},
 				}}, nil)
 				m.CreateOrganization(organizations.NewCreateOrgParams().WithBody(
+					//nolint:gosec
 					params.CreateOrgParams{
 						Name:            "existing-organization",
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&organizations.CreateOrgOK{
+					//nolint:gosec
 					Payload: params.Organization{
 						Name:            "existing-organization",
 						CredentialsName: "github-creds",
@@ -810,10 +823,12 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 				}, nil)
 				m.UpdateOrganization(organizations.NewUpdateOrgParams().
 					WithOrgID("9e0da3cb-130b-428d-aa8a-e314d955060e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&organizations.UpdateOrgOK{
+					//nolint:gosec
 					Payload: params.Organization{
 						ID:              "9e0da3cb-130b-428d-aa8a-e314d955060e",
 						Name:            "existing-organization",
@@ -937,10 +952,10 @@ func TestOrganizationReconciler_reconcileNormal(t *testing.T) {
 			}
 
 			// clear out annotations to avoid comparison errors
-			organization.ObjectMeta.Annotations = nil
+			organization.Annotations = nil
 
 			// empty resource version to avoid comparison errors
-			organization.ObjectMeta.ResourceVersion = ""
+			organization.ResourceVersion = ""
 
 			// clear conditions lastTransitionTime to avoid comparison errors
 			conditions.NilLastTransitionTime(tt.expectedObject)

--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -101,7 +101,7 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res c
 	}()
 
 	// handle deletion
-	if !pool.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !pool.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(ctx, poolClient, pool, instanceClient)
 	}
 
@@ -203,8 +203,8 @@ func (r *PoolReconciler) reconcileUpdate(ctx context.Context, garmClient garmCli
 
 	longRunningIdleRunnersCount := len(runnerUtil.OldIdleRunners(config.Config.Operator.MinIdleRunnersAge, idleRunners))
 
-	switch {
-	case pool.Spec.MinIdleRunners == 0:
+	switch pool.Spec.MinIdleRunners {
+	case 0:
 		// scale to zero
 		// when scale to zero is desired, we immediately scale down to zero by deleting all idle runners
 

--- a/internal/controller/pool_controller_test.go
+++ b/internal/controller/pool_controller_test.go
@@ -1367,10 +1367,10 @@ func TestPoolController_ReconcileCreate(t *testing.T) {
 			}
 
 			// clear out annotations to avoid comparison errors
-			pool.ObjectMeta.Annotations = nil
+			pool.Annotations = nil
 
 			// empty resource version to avoid comparison errors
-			pool.ObjectMeta.ResourceVersion = ""
+			pool.ResourceVersion = ""
 
 			// clear conditions lastTransitionTime to avoid comparison errors
 			conditions.NilLastTransitionTime(tt.expectedObject)
@@ -1853,7 +1853,7 @@ func TestPoolController_ReconcileDelete(t *testing.T) {
 			}
 
 			// empty resource version to avoid comparison errors
-			pool.ObjectMeta.ResourceVersion = ""
+			pool.ResourceVersion = ""
 			pool.Spec.GitHubScopeRef.APIGroup = nil
 			conditions.NilLastTransitionTime(pool)
 			conditions.NilLastTransitionTime(tt.expectedObject)

--- a/internal/controller/repository_controller_test.go
+++ b/internal/controller/repository_controller_test.go
@@ -145,6 +145,7 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 			},
 			expectGarmRequest: func(m *mock.MockRepositoryClientMockRecorder) {
 				m.ListRepositories(repositories.NewListReposParams()).Return(&repositories.ListReposOK{Payload: params.Repositories{
+					//nolint:gosec
 					{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-repository",
@@ -155,10 +156,12 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 				}}, nil)
 				m.UpdateRepository(repositories.NewUpdateRepoParams().
 					WithRepoID("e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&repositories.UpdateRepoOK{
+					//nolint:gosec
 					Payload: params.Repository{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-repository",
@@ -277,6 +280,7 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 			},
 			expectGarmRequest: func(m *mock.MockRepositoryClientMockRecorder) {
 				m.ListRepositories(repositories.NewListReposParams()).Return(&repositories.ListReposOK{Payload: params.Repositories{
+					//nolint:gosec
 					{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-repository",
@@ -287,10 +291,12 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 				}}, nil)
 				m.UpdateRepository(repositories.NewUpdateRepoParams().
 					WithRepoID("e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "has-changed",
 						WebhookSecret:   "has-changed",
 					})).Return(&repositories.UpdateRepoOK{
+					//nolint:gosec
 					Payload: params.Repository{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-repository",
@@ -409,6 +415,7 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 			},
 			expectGarmRequest: func(m *mock.MockRepositoryClientMockRecorder) {
 				m.ListRepositories(repositories.NewListReposParams()).Return(&repositories.ListReposOK{Payload: params.Repositories{
+					//nolint:gosec
 					{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-repository",
@@ -419,10 +426,12 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 				}}, nil)
 				m.UpdateRepository(repositories.NewUpdateRepoParams().
 					WithRepoID("e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&repositories.UpdateRepoOK{
+					//nolint:gosec
 					Payload: params.Repository{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-repository",
@@ -542,6 +551,7 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 			},
 			expectGarmRequest: func(m *mock.MockRepositoryClientMockRecorder) {
 				m.ListRepositories(repositories.NewListReposParams()).Return(&repositories.ListReposOK{Payload: params.Repositories{
+					//nolint:gosec
 					{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-ae78a8f27a3e",
 						Name:            "existing-repository",
@@ -551,12 +561,14 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 					},
 				}}, nil)
 				m.CreateRepository(repositories.NewCreateRepoParams().WithBody(
+					//nolint:gosec
 					params.CreateRepoParams{
 						Name:            "new-repository",
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 						Owner:           "test-repo",
 					})).Return(&repositories.CreateRepoOK{
+					//nolint:gosec
 					Payload: params.Repository{
 						Name:            "new-repository",
 						ID:              "9e0da3cb-130b-428d-aa8a-e314d955060e",
@@ -567,10 +579,12 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 				}, nil)
 				m.UpdateRepository(repositories.NewUpdateRepoParams().
 					WithRepoID("9e0da3cb-130b-428d-aa8a-e314d955060e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&repositories.UpdateRepoOK{
+					//nolint:gosec
 					Payload: params.Repository{
 						ID:              "9e0da3cb-130b-428d-aa8a-e314d955060e",
 						Name:            "new-repository",
@@ -686,6 +700,7 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 			},
 			expectGarmRequest: func(m *mock.MockRepositoryClientMockRecorder) {
 				m.ListRepositories(repositories.NewListReposParams()).Return(&repositories.ListReposOK{Payload: params.Repositories{
+					//nolint:gosec
 					{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-12345",
 						Name:            "new-repository",
@@ -695,10 +710,12 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 				}}, nil)
 				m.UpdateRepository(repositories.NewUpdateRepoParams().
 					WithRepoID("e1dbf9a6-a9f6-4594-a5ac-12345").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&repositories.UpdateRepoOK{
+					//nolint:gosec
 					Payload: params.Repository{
 						ID:              "e1dbf9a6-a9f6-4594-a5ac-12345",
 						Name:            "new-repository",
@@ -820,12 +837,14 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 					{},
 				}}, nil)
 				m.CreateRepository(repositories.NewCreateRepoParams().WithBody(
+					//nolint:gosec
 					params.CreateRepoParams{
 						Name:            "existing-repository",
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 						Owner:           "test-repo",
 					})).Return(&repositories.CreateRepoOK{
+					//nolint:gosec
 					Payload: params.Repository{
 						Name:            "existing-repository",
 						ID:              "9e0da3cb-130b-428d-aa8a-e314d955060e",
@@ -836,10 +855,12 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 				}, nil)
 				m.UpdateRepository(repositories.NewUpdateRepoParams().
 					WithRepoID("9e0da3cb-130b-428d-aa8a-e314d955060e").
+					//nolint:gosec
 					WithBody(params.UpdateEntityParams{
 						CredentialsName: "github-creds",
 						WebhookSecret:   "foobar",
 					})).Return(&repositories.UpdateRepoOK{
+					//nolint:gosec
 					Payload: params.Repository{
 						ID:              "9e0da3cb-130b-428d-aa8a-e314d955060e",
 						Name:            "existing-repository",
@@ -964,10 +985,10 @@ func TestRepositoryReconciler_reconcileNormal(t *testing.T) {
 			}
 
 			// clear out annotations to avoid comparison errors
-			repository.ObjectMeta.Annotations = nil
+			repository.Annotations = nil
 
 			// empty resource version to avoid comparison errors
-			repository.ObjectMeta.ResourceVersion = ""
+			repository.ResourceVersion = ""
 
 			// clear conditions lastTransitionTime to avoid comparison errors
 			conditions.NilLastTransitionTime(tt.expectedObject)

--- a/internal/controller/runner_controller.go
+++ b/internal/controller/runner_controller.go
@@ -65,7 +65,7 @@ func (r *RunnerReconciler) reconcileNormal(ctx context.Context, req ctrl.Request
 
 	switch {
 	// found Runner CR and matching garm runner or RunnerCR is already in deleting state, continue with reconcile
-	case err == nil && garmRunner != nil || !runner.ObjectMeta.DeletionTimestamp.IsZero():
+	case err == nil && garmRunner != nil || !runner.DeletionTimestamp.IsZero():
 		log.Info("Found Runner CR and matching garm runner, continue with reconcile", "runner", runner.Name)
 
 	// Found RunnerCR but no matching garm runner, delete the RunnerCR
@@ -108,7 +108,7 @@ func (r *RunnerReconciler) reconcileNormal(ctx context.Context, req ctrl.Request
 	}()
 
 	// delete runner in garm db
-	if !runner.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !runner.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(ctx, instanceClient, runner, garmRunner)
 	}
 

--- a/internal/controller/runner_controller_test.go
+++ b/internal/controller/runner_controller_test.go
@@ -171,10 +171,10 @@ func TestRunnerReconciler_reconcileCreate(t *testing.T) {
 			}
 
 			// clear out annotations to avoid comparison errors
-			runner.ObjectMeta.Annotations = nil
+			runner.Annotations = nil
 
 			// empty resource version to avoid comparison errors
-			runner.ObjectMeta.ResourceVersion = ""
+			runner.ResourceVersion = ""
 
 			if !reflect.DeepEqual(runner, tt.expectedObject) {
 				t.Errorf("RunnerReconciler.reconcile() \ngot = %#v\n want %#v", runner, tt.expectedObject)

--- a/pkg/client/controller.go
+++ b/pkg/client/controller.go
@@ -3,7 +3,6 @@ package client
 
 import (
 	"github.com/cloudbase/garm/client/controller"
-	garmcontroller "github.com/cloudbase/garm/client/controller"
 	"github.com/cloudbase/garm/client/controller_info"
 	"github.com/cloudbase/garm/params"
 
@@ -42,7 +41,7 @@ func (s *controllerClient) GetControllerInfo() (*controller_info.ControllerInfoO
 			// after the first run, garm needs a configuration for webhook, metadata and callback
 			// to make garm work after the first run, we set some defaults
 			if IsConflictError(err) {
-				updateParams := garmcontroller.NewUpdateControllerParams().WithBody(params.UpdateControllerParams{
+				updateParams := controller.NewUpdateControllerParams().WithBody(params.UpdateControllerParams{
 					MetadataURL: util.StringPtr(initialMetadataURL),
 					CallbackURL: util.StringPtr(initialCallbackURL),
 					WebhookURL:  util.StringPtr(initialWebhookURL),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,7 +54,7 @@ func GenerateConfig(f *pflag.FlagSet, configFile string) error {
 	k := koanf.New(".")
 
 	// load config from envs with prefix OPERATOR_
-	k.Load(env.Provider("OPERATOR_", ".", func(s string) string {
+	err := k.Load(env.Provider("OPERATOR_", ".", func(s string) string {
 		// Transform env e.g. from OPERATOR_SYNC_PERIOD to operator.syncPeriod (camel case)
 		key := strings.SplitN(s, "_", 2)
 
@@ -66,9 +66,12 @@ func GenerateConfig(f *pflag.FlagSet, configFile string) error {
 
 		return res
 	}), nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to load operator config from environment variables")
+	}
 
 	// load config from envs with prefix GARM_
-	k.Load(env.Provider("GARM_", ".", func(s string) string {
+	err = k.Load(env.Provider("GARM_", ".", func(s string) string {
 		// Transform env e.g. from GARM_SERVER to garm.server (camel case)
 		key := strings.SplitN(s, "_", 2)
 
@@ -80,10 +83,13 @@ func GenerateConfig(f *pflag.FlagSet, configFile string) error {
 
 		return res
 	}), nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to load garm config from environment variables")
+	}
 
 	// load config from flags
 	if f != nil {
-		k.Load(posflag.ProviderWithFlag(f, ".", k, func(pf *pflag.Flag) (string, interface{}) {
+		err = k.Load(posflag.ProviderWithFlag(f, ".", k, func(pf *pflag.Flag) (string, interface{}) {
 			// Transform flag e.g. from operator-sync-period to operator.syncPeriod (camel case)
 			key := strings.SplitN(pf.Name, "-", 2)
 
@@ -102,6 +108,9 @@ func GenerateConfig(f *pflag.FlagSet, configFile string) error {
 
 			return res, val
 		}), nil)
+		if err != nil {
+			return errors.Wrap(err, "failed to load config from flags")
+		}
 	}
 
 	// load config from file

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -241,7 +241,9 @@ func TestGenerateConfig(t *testing.T) {
 			var configFile string
 
 			for k, v := range tt.flags {
-				f.Set(k, v)
+				if err := f.Set(k, v); err != nil {
+					t.Fatalf("failed to set flag %s: %v", k, err)
+				}
 				if k == "config" {
 					configFile = v
 				}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -2,8 +2,10 @@
 
 package filter
 
+// Predicate is a function that takes an item of type T and returns a boolean indicating whether the item matches certain criteria
 type Predicate[T any] func(T) bool
 
+// Match takes a slice of items and a variadic number of predicates, and returns a slice of items that match all the predicates
 func Match[T any](items []T, predicates ...Predicate[T]) []T {
 	var resultList []T
 

--- a/pkg/finalizers/finalizers.go
+++ b/pkg/finalizers/finalizers.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+// EnsureFinalizer ensures that the given finalizer is present on the object. It returns true if the finalizer was added, and false if it was already present or if the object is being deleted.
 func EnsureFinalizer(ctx context.Context, c client.Client, o client.Object, finalizer string) (finalizerAdded bool, err error) {
 	// Finalizers can only be added when the deletionTimestamp is not set.
 	if !o.GetDeletionTimestamp().IsZero() {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -47,7 +47,10 @@ func InitiateFlags() *pflag.FlagSet {
 
 	f.Bool("dry-run", false, "If true, only print the object that would be sent, without sending it.")
 
-	f.Parse(os.Args[1:])
+	if err := f.Parse(os.Args[1:]); err != nil {
+		fmt.Printf("Error parsing flags: %v\n", err)
+		os.Exit(1)
+	}
 
 	return f
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,6 +16,7 @@ const (
 )
 
 var (
+	// GarmJwtExpiresAt is a Prometheus gauge that tracks the expiration timestamp of the JWT
 	GarmJwtExpiresAt = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metricNamespace,
 		Subsystem: garmClient,
@@ -26,6 +27,7 @@ var (
 		},
 	})
 
+	// TotalGarmCalls is a Prometheus counter that tracks the total number of GARM API calls
 	TotalGarmCalls = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricNamespace,
@@ -37,6 +39,7 @@ var (
 			},
 		}, []string{"method"})
 
+	// GarmCallErrors is a Prometheus counter that tracks the number of GARM API calls that failed
 	GarmCallErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricNamespace,

--- a/pkg/pools/predicate.go
+++ b/pkg/pools/predicate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mercedes-benz/garm-operator/pkg/filter"
 )
 
+// MatchesGitHubScope returns a predicate that matches pools with the given GitHub scope and ID
 func MatchesGitHubScope(scope garmoperatorv1beta1.GitHubScopeKind, id string) filter.Predicate[params.Pool] {
 	return func(p params.Pool) bool {
 		if scope == garmoperatorv1beta1.EnterpriseScope {
@@ -26,18 +27,21 @@ func MatchesGitHubScope(scope garmoperatorv1beta1.GitHubScopeKind, id string) fi
 	}
 }
 
+// MatchesImage returns a predicate that matches pools with the given image
 func MatchesImage(image string) filter.Predicate[params.Pool] {
 	return func(p params.Pool) bool {
 		return p.Image == image
 	}
 }
 
+// MatchesFlavor returns a predicate that matches pools with the given flavor
 func MatchesFlavor(flavor string) filter.Predicate[params.Pool] {
 	return func(p params.Pool) bool {
 		return p.Flavor == flavor
 	}
 }
 
+// MatchesProvider returns a predicate that matches pools with the given provider
 func MatchesProvider(provider string) filter.Predicate[params.Pool] {
 	return func(p params.Pool) bool {
 		return p.ProviderName == provider

--- a/pkg/runners/predicate.go
+++ b/pkg/runners/predicate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mercedes-benz/garm-operator/pkg/filter"
 )
 
+// MatchesName returns a predicate that matches instances with the given name
 func MatchesName(name string) filter.Predicate[params.Instance] {
 	return func(i params.Instance) bool {
 		return strings.EqualFold(i.Name, name)

--- a/pkg/runners/runners.go
+++ b/pkg/runners/runners.go
@@ -15,6 +15,7 @@ import (
 	garmClient "github.com/mercedes-benz/garm-operator/pkg/client"
 )
 
+// GetRunnersByPoolID returns a list of runners for a given pool ID
 func GetRunnersByPoolID(ctx context.Context, pool *garmoperatorv1beta1.Pool, instanceClient garmClient.InstanceClient) ([]params.Instance, error) {
 	log := log.FromContext(ctx)
 	log.Info("discover idle runners", "pool", pool.Name)

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -21,6 +21,7 @@ import (
 // set distinct and unique labels on each pool, and explicitly target those labels, or risk assigning
 // the job to the wrong worker type.
 
+// CreateComparableRunnerTags creates a list of tags for a runner that can be used for comparison
 func CreateComparableRunnerTags(poolTags []string, osArch providerParams.OSArch, osType providerParams.OSType) ([]params.Tag, error) {
 	githubDefaultTags, err := getGithubDefaultTags(osArch, osType)
 	if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
+
 package util
 
+// StringPtr returns a pointer to the given string
 func StringPtr(s string) *string {
 	return &s
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,8 +4,10 @@ package version
 
 import "golang.org/x/mod/semver"
 
+// MinVersion is the minimum required version of garm that the operator supports
 const MinVersion = "v0.1.5"
 
+// EnsureMinimalVersion checks if the given version is greater than or equal to the minimum required version
 func EnsureMinimalVersion(version string) bool {
 	return semver.Compare(version, MinVersion) >= 0
 }


### PR DESCRIPTION
golangci-lint has done a major version bump a while ago. this bumps the golangi-lint to the latest v2 version and also fixes some linter findings