### PR TITLE
chore: bump golang to version 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Build the manager binary
-FROM golang:1.25.5 as builder
+FROM golang:1.26.2 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 module github.com/mercedes-benz/garm-operator
 
-go 1.25.5
+go 1.26.2
 
 require (
 	github.com/cloudbase/garm v0.1.5


### PR DESCRIPTION
to fix some CVEs from the current used go version 1.25.5 it's necessary to update to the latest version of go