### PR TITLE
feat(client): add repo and org webhook API wrappers

### DIFF
--- a/pkg/client/mock/organization.go
+++ b/pkg/client/mock/organization.go
@@ -113,3 +113,47 @@ func (mr *MockOrganizationClientMockRecorder) UpdateOrganization(param any) *gom
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOrganization", reflect.TypeOf((*MockOrganizationClient)(nil).UpdateOrganization), param)
 }
+
+// GetOrgWebhookInfo mocks base method.
+func (m *MockOrganizationClient) GetOrgWebhookInfo(param *organizations.GetOrgWebhookInfoParams) (*organizations.GetOrgWebhookInfoOK, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrgWebhookInfo", param)
+	ret0, _ := ret[0].(*organizations.GetOrgWebhookInfoOK)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrgWebhookInfo indicates an expected call of GetOrgWebhookInfo.
+func (mr *MockOrganizationClientMockRecorder) GetOrgWebhookInfo(param any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgWebhookInfo", reflect.TypeOf((*MockOrganizationClient)(nil).GetOrgWebhookInfo), param)
+}
+
+// InstallOrgWebhook mocks base method.
+func (m *MockOrganizationClient) InstallOrgWebhook(param *organizations.InstallOrgWebhookParams) (*organizations.InstallOrgWebhookOK, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallOrgWebhook", param)
+	ret0, _ := ret[0].(*organizations.InstallOrgWebhookOK)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InstallOrgWebhook indicates an expected call of InstallOrgWebhook.
+func (mr *MockOrganizationClientMockRecorder) InstallOrgWebhook(param any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallOrgWebhook", reflect.TypeOf((*MockOrganizationClient)(nil).InstallOrgWebhook), param)
+}
+
+// UninstallOrgWebhook mocks base method.
+func (m *MockOrganizationClient) UninstallOrgWebhook(param *organizations.UninstallOrgWebhookParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UninstallOrgWebhook", param)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UninstallOrgWebhook indicates an expected call of UninstallOrgWebhook.
+func (mr *MockOrganizationClientMockRecorder) UninstallOrgWebhook(param any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallOrgWebhook", reflect.TypeOf((*MockOrganizationClient)(nil).UninstallOrgWebhook), param)
+}

--- a/pkg/client/mock/repository.go
+++ b/pkg/client/mock/repository.go
@@ -113,3 +113,47 @@ func (mr *MockRepositoryClientMockRecorder) UpdateRepository(param any) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRepository", reflect.TypeOf((*MockRepositoryClient)(nil).UpdateRepository), param)
 }
+
+// GetRepoWebhookInfo mocks base method.
+func (m *MockRepositoryClient) GetRepoWebhookInfo(param *repositories.GetRepoWebhookInfoParams) (*repositories.GetRepoWebhookInfoOK, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRepoWebhookInfo", param)
+	ret0, _ := ret[0].(*repositories.GetRepoWebhookInfoOK)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRepoWebhookInfo indicates an expected call of GetRepoWebhookInfo.
+func (mr *MockRepositoryClientMockRecorder) GetRepoWebhookInfo(param any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepoWebhookInfo", reflect.TypeOf((*MockRepositoryClient)(nil).GetRepoWebhookInfo), param)
+}
+
+// InstallRepoWebhook mocks base method.
+func (m *MockRepositoryClient) InstallRepoWebhook(param *repositories.InstallRepoWebhookParams) (*repositories.InstallRepoWebhookOK, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallRepoWebhook", param)
+	ret0, _ := ret[0].(*repositories.InstallRepoWebhookOK)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InstallRepoWebhook indicates an expected call of InstallRepoWebhook.
+func (mr *MockRepositoryClientMockRecorder) InstallRepoWebhook(param any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallRepoWebhook", reflect.TypeOf((*MockRepositoryClient)(nil).InstallRepoWebhook), param)
+}
+
+// UninstallRepoWebhook mocks base method.
+func (m *MockRepositoryClient) UninstallRepoWebhook(param *repositories.UninstallRepoWebhookParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UninstallRepoWebhook", param)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UninstallRepoWebhook indicates an expected call of UninstallRepoWebhook.
+func (mr *MockRepositoryClientMockRecorder) UninstallRepoWebhook(param any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallRepoWebhook", reflect.TypeOf((*MockRepositoryClient)(nil).UninstallRepoWebhook), param)
+}

--- a/pkg/client/organization.go
+++ b/pkg/client/organization.go
@@ -14,6 +14,9 @@ type OrganizationClient interface {
 	GetOrganization(param *organizations.GetOrgParams) (*organizations.GetOrgOK, error)
 	UpdateOrganization(param *organizations.UpdateOrgParams) (*organizations.UpdateOrgOK, error)
 	DeleteOrganization(param *organizations.DeleteOrgParams) error
+	InstallOrgWebhook(param *organizations.InstallOrgWebhookParams) (*organizations.InstallOrgWebhookOK, error)
+	GetOrgWebhookInfo(param *organizations.GetOrgWebhookInfoParams) (*organizations.GetOrgWebhookInfoOK, error)
+	UninstallOrgWebhook(param *organizations.UninstallOrgWebhookParams) error
 }
 
 type organizationClient struct {
@@ -85,4 +88,41 @@ func (s *organizationClient) UpdateOrganization(param *organizations.UpdateOrgPa
 		}
 		return organization, nil
 	})
+}
+
+func (s *organizationClient) InstallOrgWebhook(param *organizations.InstallOrgWebhookParams) (*organizations.InstallOrgWebhookOK, error) {
+	return EnsureAuth(func() (*organizations.InstallOrgWebhookOK, error) {
+		metrics.TotalGarmCalls.WithLabelValues("organization.InstallWebhook").Inc()
+		webhook, err := s.GarmAPI().Organizations.InstallOrgWebhook(param, s.Token())
+		if err != nil {
+			metrics.GarmCallErrors.WithLabelValues("organization.InstallWebhook").Inc()
+			return nil, err
+		}
+		return webhook, nil
+	})
+}
+
+func (s *organizationClient) GetOrgWebhookInfo(param *organizations.GetOrgWebhookInfoParams) (*organizations.GetOrgWebhookInfoOK, error) {
+	return EnsureAuth(func() (*organizations.GetOrgWebhookInfoOK, error) {
+		metrics.TotalGarmCalls.WithLabelValues("organization.GetWebhookInfo").Inc()
+		webhook, err := s.GarmAPI().Organizations.GetOrgWebhookInfo(param, s.Token())
+		if err != nil {
+			metrics.GarmCallErrors.WithLabelValues("organization.GetWebhookInfo").Inc()
+			return nil, err
+		}
+		return webhook, nil
+	})
+}
+
+func (s *organizationClient) UninstallOrgWebhook(param *organizations.UninstallOrgWebhookParams) error {
+	_, err := EnsureAuth(func() (interface{}, error) {
+		metrics.TotalGarmCalls.WithLabelValues("organization.UninstallWebhook").Inc()
+		err := s.GarmAPI().Organizations.UninstallOrgWebhook(param, s.Token())
+		if err != nil {
+			metrics.GarmCallErrors.WithLabelValues("organization.UninstallWebhook").Inc()
+			return nil, err
+		}
+		return nil, nil
+	})
+	return err
 }

--- a/pkg/client/repository.go
+++ b/pkg/client/repository.go
@@ -14,6 +14,9 @@ type RepositoryClient interface {
 	GetRepository(param *repositories.GetRepoParams) (*repositories.GetRepoOK, error)
 	UpdateRepository(param *repositories.UpdateRepoParams) (*repositories.UpdateRepoOK, error)
 	DeleteRepository(param *repositories.DeleteRepoParams) error
+	InstallRepoWebhook(param *repositories.InstallRepoWebhookParams) (*repositories.InstallRepoWebhookOK, error)
+	GetRepoWebhookInfo(param *repositories.GetRepoWebhookInfoParams) (*repositories.GetRepoWebhookInfoOK, error)
+	UninstallRepoWebhook(param *repositories.UninstallRepoWebhookParams) error
 }
 
 type repositoryClient struct {
@@ -85,4 +88,41 @@ func (s *repositoryClient) UpdateRepository(param *repositories.UpdateRepoParams
 		}
 		return repository, nil
 	})
+}
+
+func (s *repositoryClient) InstallRepoWebhook(param *repositories.InstallRepoWebhookParams) (*repositories.InstallRepoWebhookOK, error) {
+	return EnsureAuth(func() (*repositories.InstallRepoWebhookOK, error) {
+		metrics.TotalGarmCalls.WithLabelValues("repository.InstallWebhook").Inc()
+		webhook, err := s.GarmAPI().Repositories.InstallRepoWebhook(param, s.Token())
+		if err != nil {
+			metrics.GarmCallErrors.WithLabelValues("repository.InstallWebhook").Inc()
+			return nil, err
+		}
+		return webhook, nil
+	})
+}
+
+func (s *repositoryClient) GetRepoWebhookInfo(param *repositories.GetRepoWebhookInfoParams) (*repositories.GetRepoWebhookInfoOK, error) {
+	return EnsureAuth(func() (*repositories.GetRepoWebhookInfoOK, error) {
+		metrics.TotalGarmCalls.WithLabelValues("repository.GetWebhookInfo").Inc()
+		webhook, err := s.GarmAPI().Repositories.GetRepoWebhookInfo(param, s.Token())
+		if err != nil {
+			metrics.GarmCallErrors.WithLabelValues("repository.GetWebhookInfo").Inc()
+			return nil, err
+		}
+		return webhook, nil
+	})
+}
+
+func (s *repositoryClient) UninstallRepoWebhook(param *repositories.UninstallRepoWebhookParams) error {
+	_, err := EnsureAuth(func() (interface{}, error) {
+		metrics.TotalGarmCalls.WithLabelValues("repository.UninstallWebhook").Inc()
+		err := s.GarmAPI().Repositories.UninstallRepoWebhook(param, s.Token())
+		if err != nil {
+			metrics.GarmCallErrors.WithLabelValues("repository.UninstallWebhook").Inc()
+			return nil, err
+		}
+		return nil, nil
+	})
+	return err
 }


### PR DESCRIPTION
## Summary
- First slice for [#235](https://github.com/mercedes-benz/garm-operator/issues/235): client wrappers for repository/organization webhook install, info, and uninstall.
- Updates corresponding gomock mocks so controllers can depend on the new interface methods next.

## Test plan
- [x] `go test ./pkg/client/`
- [ ] CI build / lint
- [ ] CLA-assistant signed

Follow-up (not in this PR): Webhook CRD + controller wiring.