### PR TITLE
feat(chart): add helm chart for deploying garm-operator (#138)

### DIFF
--- a/.github/testdata/chart-values.yaml
+++ b/.github/testdata/chart-values.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+
+garm:
+  server: http://garm-mock.default.svc.cluster.local:8080
+  username: test
+  password: test
+
+operator:
+  watchNamespace: ""
+  runnerReconciliation: false
+
+certManager:
+  enable: true
+
+webhook:
+  enable: true

--- a/.github/testdata/garm-mock.yaml
+++ b/.github/testdata/garm-mock.yaml
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MIT
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: garm-mock
+data:
+  server.py: |
+    import json
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+    class Handler(BaseHTTPRequestHandler):
+        def respond(self, status, body):
+            payload = json.dumps(body).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_GET(self):
+            if self.path == "/api/v1/controller-info":
+                self.respond(200, {
+                    "controller_id": "00000000-0000-0000-0000-000000000001",
+                    "hostname": "garm-mock",
+                    "metadata_url": "http://garm-mock/metadata",
+                    "callback_url": "http://garm-mock/callbacks",
+                    "webhook_url": "http://garm-mock/webhooks",
+                    "controller_webhook_url": "http://garm-mock/webhooks/controller",
+                    "minimum_job_age_backoff": 0,
+                    "version": "v0.1.5",
+                })
+                return
+            self.respond(200, {})
+
+        def do_POST(self):
+            if self.path == "/api/v1/first-run":
+                self.respond(409, {})
+                return
+            if self.path == "/api/v1/auth/login":
+                self.respond(200, {
+                    "token": "eyJhbGciOiJub25lIn0.eyJleHAiOjQxMDI0NDQ4MDB9.",
+                })
+                return
+            self.respond(200, {})
+
+        def log_message(self, format, *args):
+            return
+
+
+    HTTPServer(("0.0.0.0", 8080), Handler).serve_forever()
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: garm-mock
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: garm-mock
+  template:
+    metadata:
+      labels:
+        app: garm-mock
+    spec:
+      containers:
+        - name: garm-mock
+          image: python:3.14.0-alpine3.22@sha256:8373231e1e906ddfb457748bfc032c4c06ada8c759b7b62d9c73ec2a3c56e710
+          command:
+            - python
+            - /app/server.py
+          env:
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: server
+              mountPath: /app
+              readOnly: true
+      volumes:
+        - name: server
+          configMap:
+            name: garm-mock
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: garm-mock
+spec:
+  selector:
+    app: garm-mock
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MIT
+
+name: test-chart
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CERT_MANAGER_VERSION: v1.17.1
+  IMG: controller:latest
+  KIND_CLUSTER: garm-operator-chart
+
+jobs:
+  test-chart:
+    name: lint and install chart
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install Helm
+        run: |
+          make helm
+          echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
+
+      - name: Verify chart and CRDs
+        run: |
+          make verify-chart
+          make verify-helm IMG="$IMG"
+
+      - name: Build controller image
+        run: docker build --tag "$IMG" .
+
+      - name: Install Kind
+        run: |
+          make kind
+          bin/kind version
+
+      - name: Create Kind cluster
+        run: bin/kind create cluster --name "$KIND_CLUSTER"
+
+      - name: Load controller image
+        run: bin/kind load docker-image "$IMG" --name "$KIND_CLUSTER"
+
+      - name: Install cert-manager via Helm
+        run: |
+          bin/helm repo add jetstack https://charts.jetstack.io
+          bin/helm repo update
+          bin/helm upgrade --install cert-manager jetstack/cert-manager \
+            --version "$CERT_MANAGER_VERSION" \
+            --namespace cert-manager \
+            --create-namespace \
+            --set crds.enabled=true \
+            --wait \
+            --timeout 5m
+
+      - name: Deploy GARM mock
+        run: |
+          kubectl apply -f .github/testdata/garm-mock.yaml
+          kubectl rollout status deployment/garm-mock --timeout=2m
+
+      - name: Install chart
+        run: |
+          make helm-deploy \
+            IMG="$IMG" \
+            HELM_EXTRA_ARGS="-f .github/testdata/chart-values.yaml"
+
+      - name: Verify deployment
+        run: |
+          kubectl rollout status deployment/garm-operator-controller-manager \
+            --namespace garm-operator-system \
+            --timeout=5m
+          kubectl get crd enterprises.garm-operator.mercedes-benz.com
+          kubectl get validatingwebhookconfiguration garm-operator-validating-webhook-configuration
+          make helm-status
+
+      - name: Upgrade chart
+        run: |
+          make helm-deploy \
+            IMG="$IMG" \
+            HELM_EXTRA_ARGS="-f .github/testdata/chart-values.yaml --set manager.replicas=2"
+          test "$(kubectl get deployment/garm-operator-controller-manager \
+            --namespace garm-operator-system \
+            -o jsonpath='{.spec.replicas}')" -eq 2
+          test "$(bin/helm history garm-operator --namespace garm-operator-system --max 1 -o json | jq -r '.[0].revision')" -eq 2
+
+      - name: Uninstall chart
+        run: |
+          make helm-uninstall
+          if bin/helm status garm-operator --namespace garm-operator-system; then
+            echo "Helm release still exists after uninstall"
+            exit 1
+          fi
+
+      - name: Delete Kind cluster
+        if: always()
+        run: bin/kind delete cluster --name "$KIND_CLUSTER"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,7 @@ before:
   hooks:
     - go mod tidy
     - sh -c "IMG=ghcr.io/mercedes-benz/garm-operator/{{ .ProjectName }}:v{{ .Version }} make release-manifests"
+    - sh -c "IMG=ghcr.io/mercedes-benz/garm-operator/{{ .ProjectName }}:v{{ .Version }} VERSION={{ .Version }} make release-helm"
 builds:
   - env:
       - CGO_ENABLED=0
@@ -63,6 +64,7 @@ release:
     - glob: tmp/garm_operator_all.yaml
     - glob: tmp/garm_operator_crds.yaml
     - glob: tmp/garm_operator.yaml
+    - glob: tmp/garm-operator-*.tgz
     - glob: tmp/garm-operator.bom.spdx
     - glob: tmp/3RD_PARTY_LICENSES.txt
     - glob: tmp/BlackDuck_RiskReport.pdf
@@ -72,5 +74,6 @@ release:
     * `garm_operator.yaml` contains the operator deployment manifest with all the required RBAC rules and certificate configurations.
     * `garm_operator_crds.yaml` contains the CRDs for the operator.
     * `garm_operator_all.yaml` is the combination of the above two files.
+    * `garm-operator-{{ .Version }}.tgz` contains the Helm chart for deploying the operator.
 
     ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Build the manager binary
-FROM golang:1.26.5 as builder
+FROM golang:1.26.6 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,15 @@ release-manifests: manifests kustomize slice ## Generate manifests for releasing
 	$(SLICE) -f tmp/garm_operator_all.yaml --include-kind CustomResourceDefinition --template "garm_operator_crds.yaml" -o tmp/
 	$(SLICE) -f tmp/garm_operator_all.yaml --exclude-kind CustomResourceDefinition --template "garm_operator.yaml" -o tmp/
 
+.PHONY: release-helm
+release-helm: helm verify-helm verify-chart ## Package the Helm chart for release. VERSION must not include a leading v.
+	@test -n "$(VERSION)" || { echo "VERSION is required"; exit 1; }
+	mkdir -p tmp
+	$(HELM) package $(HELM_CHART_DIR) \
+		--version "$(VERSION)" \
+		--app-version "v$(VERSION)" \
+		--destination tmp
+
 ##@ Build Dependencies
 
 ## Location to install dependencies to
@@ -176,6 +185,7 @@ SLICE ?= $(LOCALBIN)/kubectl-slice
 GOVULNCHECK ?= $(LOCALBIN)/govulncheck
 KBOM ?= $(LOCALBIN)/bom
 KIND ?= $(LOCALBIN)/kind
+HELM ?= $(LOCALBIN)/helm
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.0.1
@@ -190,6 +200,7 @@ NANCY_VERSION ?= v1.0.46
 KBOM_VERSION ?= v0.5.1
 KIND_VERSION ?= v0.30.0
 GOVULNCHECK_VERSION ?= v1.2.0
+HELM_VERSION ?= v3.17.1
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
@@ -265,6 +276,21 @@ $(KIND): $(LOCALBIN)
 	test -s $(LOCALBIN)/kind && $(LOCALBIN)/kind version | grep -q $(KIND_VERSION) || \
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kind@$(KIND_VERSION)
 
+.PHONY: helm
+helm: $(HELM) ## Download helm locally if necessary.
+$(HELM): $(LOCALBIN)
+	@if test -x $(LOCALBIN)/helm && ! $(LOCALBIN)/helm version --short | grep -q $(HELM_VERSION); then \
+		echo "$(LOCALBIN)/helm version is not expected $(HELM_VERSION). Removing it before installing."; \
+		rm -rf $(LOCALBIN)/helm; \
+	fi
+	@if ! test -s $(LOCALBIN)/helm; then \
+		echo "Installing helm $(HELM_VERSION)..."; \
+		OS=$$(go env GOOS); \
+		ARCH=$$(go env GOARCH); \
+		curl -fsSL "https://get.helm.sh/helm-$(HELM_VERSION)-$${OS}-$${ARCH}.tar.gz" | tar -zx -C $(LOCALBIN) --strip-components=1 "$${OS}-$${ARCH}/helm"; \
+		chmod +x $(LOCALBIN)/helm; \
+	fi
+
 ##@ Lint / Verify
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Run linting.
@@ -274,7 +300,7 @@ lint: $(GOLANGCI_LINT) ## Run linting.
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linte
 	GOLANGCI_LINT_EXTRA_ARGS=--fix $(MAKE) lint
 
-ALL_VERIFY_CHECKS = gen manifests doctoc license security
+ALL_VERIFY_CHECKS = gen manifests doctoc license security chart helm
 
 .PHONY: verify
 verify: $(addprefix verify-,$(ALL_VERIFY_CHECKS)) ## Run all verify-* targets
@@ -296,6 +322,19 @@ verify-manifests: manifests  ## Verify kubebuilder generated files are up to dat
 		git diff; \
 		echo "generated files are out of date, run make manifests"; exit 1; \
 	fi
+
+.PHONY: verify-chart
+verify-chart: update-chart ## Verify Helm chart templates are up to date
+	@if !(git diff --quiet charts/garm-operator/templates/crd charts/garm-operator/templates/rbac charts/garm-operator/templates/webhook charts/garm-operator/templates/monitoring); then \
+		git diff charts/garm-operator/templates; \
+		echo "chart templates are out of date, run make update-chart"; exit 1; \
+	fi
+
+.PHONY: verify-chart-crds
+verify-chart-crds: verify-chart
+
+.PHONY: verify-helm
+verify-helm: helm-lint helm-template ## Lint and render the Helm chart
 
 .PHONY: verify-doctoc
 verify-doctoc: generate-doctoc
@@ -331,3 +370,63 @@ delete-kind-cluster:
 .PHONY: tilt-up
 tilt-up: kind-cluster ## Start tilt and build kind cluster
 	tilt up
+
+##@ Helm Deployment
+
+## Helm chart directory
+HELM_CHART_DIR ?= charts/garm-operator
+## Helm release name
+HELM_RELEASE ?= garm-operator
+## Helm release namespace
+HELM_NAMESPACE ?= garm-operator-system
+## Additional arguments to pass to helm
+HELM_EXTRA_ARGS ?=
+
+.PHONY: update-chart
+update-chart: kustomize slice ## Synchronize Helm chart templates (CRDs, RBAC, Webhooks, Metrics) from Kubebuilder manifests
+	./hack/update-chart.sh
+
+.PHONY: update-chart-crds
+update-chart-crds: update-chart
+
+.PHONY: helm-lint
+helm-lint: helm ## Lint the Helm chart.
+	$(HELM) lint $(HELM_CHART_DIR)
+
+.PHONY: helm-template
+helm-template: helm ## Render the Helm chart with default and sample configurations.
+	$(HELM) template $(HELM_RELEASE) $(HELM_CHART_DIR) --namespace $(HELM_NAMESPACE) >/dev/null
+	$(HELM) template $(HELM_RELEASE) $(HELM_CHART_DIR) \
+		--namespace $(HELM_NAMESPACE) \
+		--set manager.replicas=2 \
+		--set certManager.enable=true \
+		--set webhook.enable=true \
+		--show-only templates/manager/deployment.yaml \
+		| grep -q 'replicas: 2'
+
+.PHONY: helm-deploy
+helm-deploy: helm ## Deploy operator to the K8s cluster via Helm. Specify image with IMG.
+	$(HELM) upgrade --install $(HELM_RELEASE) $(HELM_CHART_DIR) \
+		--namespace $(HELM_NAMESPACE) \
+		--create-namespace \
+		--set manager.image.repository=$${IMG%:*} \
+		--set manager.image.tag=$${IMG##*:} \
+		--wait \
+		--timeout 5m \
+		$(HELM_EXTRA_ARGS)
+
+.PHONY: helm-uninstall
+helm-uninstall: helm ## Uninstall the Helm release from the K8s cluster.
+	$(HELM) uninstall $(HELM_RELEASE) --namespace $(HELM_NAMESPACE)
+
+.PHONY: helm-status
+helm-status: helm ## Show Helm release status.
+	$(HELM) status $(HELM_RELEASE) --namespace $(HELM_NAMESPACE)
+
+.PHONY: helm-history
+helm-history: helm ## Show Helm release history.
+	$(HELM) history $(HELM_RELEASE) --namespace $(HELM_NAMESPACE)
+
+.PHONY: helm-rollback
+helm-rollback: helm ## Rollback to previous Helm release.
+	$(HELM) rollback $(HELM_RELEASE) --namespace $(HELM_NAMESPACE)

--- a/README.md
+++ b/README.md
@@ -66,11 +66,50 @@ The compatibility matrix for client-go and Kubernetes cluster can be found
 
 ### Deployment
 
-#### `garm-operator`
+#### Helm (Recommended)
+
+The operator can be deployed using the Helm chart located in `charts/garm-operator` or downloaded from GitHub releases as `garm-operator-<version>.tgz`.
+
+##### 1. Using an existing Kubernetes Secret for GARM credentials
+
+Following GitOps best practices, create a Secret containing your GARM password:
+
+```bash
+kubectl create secret generic garm-credentials \
+  --namespace garm-operator-system \
+  --create-namespace \
+  --from-literal=password='<garm-server-password>'
+```
+
+Then install the chart referencing the secret:
+
+```bash
+helm install garm-operator ./charts/garm-operator \
+  --namespace garm-operator-system \
+  --create-namespace \
+  --set garm.server="<garm-server-url>" \
+  --set garm.username="<garm-server-username>" \
+  --set garm.existingSecret="garm-credentials"
+```
+
+##### 2. Passing credentials via values
+
+```bash
+helm install garm-operator ./charts/garm-operator \
+  --namespace garm-operator-system \
+  --create-namespace \
+  --set garm.server="<garm-server-url>" \
+  --set garm.username="<garm-server-username>" \
+  --set garm.password="<garm-server-password>"
+```
+
+For more configuration options and details, please refer to the [Helm chart README](charts/garm-operator/README.md).
+
+#### Kubernetes Manifests
 
 We are releasing the `garm-operator` as container image together with the corresponding Kubernetes manifests. You can find the latest release [here](https://github.com/mercedes-benz/garm-operator/releases).
 
-This manifests can be used to deploy the `garm-operator` into your Kubernetes cluster.
+These manifests can be used to deploy the `garm-operator` into your Kubernetes cluster.
 
 ```bash
 export GARM_OPERATOR_VERSION=<garm-operator-version>

--- a/charts/garm-operator/.helmignore
+++ b/charts/garm-operator/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when packaging a Helm chart.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.bak
+*.swp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+.vscode/
+*.tmproj
+.classpath
+# Helm files
+.helmignore
+Chart.lock

--- a/charts/garm-operator/.helmignore
+++ b/charts/garm-operator/.helmignore
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 # Patterns to ignore when packaging a Helm chart.
 .DS_Store
 # Common VCS dirs

--- a/charts/garm-operator/Chart.yaml
+++ b/charts/garm-operator/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: garm-operator
+description: A Helm chart for deploying the Kubernetes GARM (GitHub Actions Runner Manager) Operator
+type: application
+version: 0.1.0
+appVersion: "v0.1.0"
+home: https://github.com/mercedes-benz/garm-operator
+sources:
+  - https://github.com/mercedes-benz/garm-operator
+keywords:
+  - garm
+  - github-actions
+  - runner
+  - operator
+  - kubernetes
+maintainers:
+  - name: mercedes-benz
+    url: https://github.com/mercedes-benz

--- a/charts/garm-operator/README.md
+++ b/charts/garm-operator/README.md
@@ -1,0 +1,111 @@
+# GARM Operator Helm Chart
+
+Helm chart for installing and configuring the [garm-operator](https://github.com/mercedes-benz/garm-operator) in Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.27+
+- Helm 3.8.0+
+- [cert-manager](https://cert-manager.io/) installed (required for admission webhook TLS certificates)
+- A running [GARM](https://github.com/cloudbase/garm) server reachable from your Kubernetes cluster
+
+## Installing the Chart
+
+### Using an Existing Secret for GARM Password (Recommended)
+
+First, create a Kubernetes Secret containing your GARM password:
+
+```bash
+kubectl create secret generic garm-credentials \
+  --namespace garm-operator-system \
+  --from-literal=password='YOUR_GARM_PASSWORD'
+```
+
+Then install the chart referencing the secret:
+
+```bash
+helm install garm-operator ./charts/garm-operator \
+  --namespace garm-operator-system \
+  --create-namespace \
+  --set garm.server="http://garm-server:9997" \
+  --set garm.username="admin" \
+  --set garm.existingSecret="garm-credentials"
+```
+
+### Providing Credentials Directly in Values
+
+```bash
+helm install garm-operator ./charts/garm-operator \
+  --namespace garm-operator-system \
+  --create-namespace \
+  --set garm.server="http://garm-server:9997" \
+  --set garm.username="admin" \
+  --set garm.password="YOUR_GARM_PASSWORD"
+```
+
+## Values Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `garm.server` | URL of the GARM server | `""` |
+| `garm.username` | GARM admin username | `""` |
+| `garm.password` | GARM admin password (ignored if `garm.existingSecret` is set) | `""` |
+| `garm.existingSecret` | Name of an existing Secret containing GARM password | `""` |
+| `garm.secretKeys.passwordKey` | Key in secret containing password | `password` |
+| `garm.secretKeys.usernameKey` | Key in secret containing username | `username` |
+| `garm.secretKeys.serverKey` | Key in secret containing server URL | `server` |
+| `garm.init` | Initialize GARM on startup | `false` |
+| `garm.email` | GARM admin email (required if `garm.init` is true) | `""` |
+| `operator.watchNamespace` | Namespace to watch for CRDs (empty watches all) | `""` |
+| `operator.metricsBindAddress` | Metrics endpoint bind address | `":8080"` |
+| `operator.healthProbeBindAddress` | Health probe bind address | `":8081"` |
+| `operator.leaderElection` | Enable leader election | `false` |
+| `operator.syncPeriod` | Controller manager sync period | `"5m0s"` |
+| `operator.syncRunnersInterval` | Runner sync interval | `"5m0s"` |
+| `operator.minIdleRunnersAge` | Minimum idle runners age before deletion | `"5m0s"` |
+| `operator.runnerConcurrency` | Runner reconciler concurrency | `20` |
+| `operator.repositoryConcurrency` | Repository reconciler concurrency | `5` |
+| `operator.organizationConcurrency` | Organization reconciler concurrency | `3` |
+| `operator.enterpriseConcurrency` | Enterprise reconciler concurrency | `1` |
+| `operator.poolConcurrency` | Pool reconciler concurrency | `10` |
+| `operator.runnerReconciliation` | Enable runner reconciliation loop | `true` |
+| `operator.logVerbosityLevel` | Log verbosity level (0-5) | `0` |
+| `operator.extraArgs` | Extra arguments passed to manager | `[]` |
+| `operator.extraEnv` | Extra environment variables | `[]` |
+| `operator.extraEnvFrom` | Extra environment variables from secrets/configmaps | `[]` |
+| `manager.replicas` | Number of operator replicas | `1` |
+| `manager.image.repository` | Image repository | `ghcr.io/mercedes-benz/garm-operator/garm-operator` |
+| `manager.image.tag` | Image tag (defaults to `Chart.appVersion`) | `""` |
+| `manager.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `manager.resources` | Resource requests and limits | limits: 500m/128Mi, requests: 10m/64Mi |
+| `serviceAccount.create` | Whether to create a ServiceAccount | `true` |
+| `rbac.create` | Whether to create RBAC resources | `true` |
+| `crd.enable` | Whether to install CRDs | `true` |
+| `crd.keep` | Retain CRDs on chart uninstall (`helm.sh/resource-policy: keep`) | `true` |
+| `webhook.enable` | Enable admission webhooks | `true` |
+| `webhook.port` | Admission webhook container port | `9443` |
+| `certManager.enable` | Enable cert-manager certificate generation for webhooks | `true` |
+| `certManager.issuerRef` | Custom Issuer reference (defaults to self-signed issuer) | `{}` |
+| `prometheus.enable` | Enable Prometheus ServiceMonitor | `false` |
+| `kubeStateMetrics.createConfigMap` | Deploy CustomResourceStateMetrics ConfigMap | `true` |
+
+## Webhook and Certificates
+
+By default, the chart enables admission webhooks and uses `cert-manager` with a self-signed issuer to provision webhook certificates. If you use an existing ClusterIssuer, specify `certManager.issuerRef`:
+
+```yaml
+certManager:
+  enable: true
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: my-cluster-issuer
+```
+
+## Uninstalling the Chart
+
+```bash
+helm uninstall garm-operator --namespace garm-operator-system
+```
+
+By default, Custom Resource Definitions (CRDs) have the `helm.sh/resource-policy: keep` annotation enabled, protecting your GARM custom resources from accidental deletion.

--- a/charts/garm-operator/README.md
+++ b/charts/garm-operator/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: MIT -->
+
 # GARM Operator Helm Chart
 
 Helm chart for installing and configuring the [garm-operator](https://github.com/mercedes-benz/garm-operator) in Kubernetes.

--- a/charts/garm-operator/templates/_helpers.tpl
+++ b/charts/garm-operator/templates/_helpers.tpl
@@ -1,0 +1,105 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "garm-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "garm-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "garm-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "garm-operator.labels" -}}
+helm.sh/chart: {{ include "garm-operator.chart" . }}
+{{ include "garm-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: garm-operator
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "garm-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "garm-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+control-plane: controller-manager
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "garm-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (printf "%s-controller-manager" (include "garm-operator.fullname" .)) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the GARM secret to use
+*/}}
+{{- define "garm-operator.secretName" -}}
+{{- if .Values.garm.existingSecret }}
+{{- .Values.garm.existingSecret }}
+{{- else }}
+{{- printf "%s-garm-secret" (include "garm-operator.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the webhook service
+*/}}
+{{- define "garm-operator.webhookServiceName" -}}
+{{- printf "%s-webhook-service" (include "garm-operator.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Aliases for compatibility
+*/}}
+{{- define "chart.name" -}}
+{{- include "garm-operator.name" . }}
+{{- end }}
+
+{{- define "chart.fullname" -}}
+{{- include "garm-operator.fullname" . }}
+{{- end }}
+
+{{- define "chart.labels" -}}
+{{- include "garm-operator.labels" . }}
+{{- end }}
+
+{{- define "chart.selectorLabels" -}}
+{{- include "garm-operator.selectorLabels" . }}
+{{- end }}
+
+{{- define "chart.serviceAccountName" -}}
+{{- include "garm-operator.serviceAccountName" . }}
+{{- end }}

--- a/charts/garm-operator/templates/_helpers.tpl
+++ b/charts/garm-operator/templates/_helpers.tpl
@@ -1,3 +1,5 @@
+{{/* SPDX-License-Identifier: MIT */}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/garm-operator/templates/cert-manager/selfsigned-issuer.yaml
+++ b/charts/garm-operator/templates/cert-manager/selfsigned-issuer.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.certManager.enable (empty .Values.certManager.issuerRef) }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: certificate
+spec:
+  selfSigned: {}
+{{- end }}

--- a/charts/garm-operator/templates/cert-manager/serving-cert.yaml
+++ b/charts/garm-operator/templates/cert-manager/serving-cert.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.certManager.enable }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-serving-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: certificate
+spec:
+  dnsNames:
+    - {{ include "garm-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "garm-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    {{- if .Values.certManager.issuerRef }}
+    {{- toYaml .Values.certManager.issuerRef | nindent 4 }}
+    {{- else }}
+    kind: Issuer
+    name: {{ include "garm-operator.fullname" . }}-selfsigned-issuer
+    {{- end }}
+  secretName: webhook-server-cert
+{{- end }}

--- a/charts/garm-operator/templates/crd/enterprises.garm-operator.mercedes-benz.com.yaml
+++ b/charts/garm-operator/templates/crd/enterprises.garm-operator.mercedes-benz.com.yaml
@@ -1,0 +1,329 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/garm-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: enterprises.garm-operator.mercedes-benz.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: garm-operator-webhook-service
+          namespace: {{ .Release.Namespace }}
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: garm-operator.mercedes-benz.com
+  names:
+    categories:
+    - garm
+    kind: Enterprise
+    listKind: EnterpriseList
+    plural: enterprises
+    shortNames:
+    - ent
+    singular: enterprise
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Enterprise ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Error
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.reason=='PoolManagerFailure')].message
+      name: Pool_Manager_Failure
+      priority: 1
+      type: string
+    - description: Time duration since creation of Enterprise
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Enterprise is the Schema for the enterprises API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EnterpriseSpec defines the desired state of Enterprise
+            properties:
+              credentialsName:
+                type: string
+              webhookSecretRef:
+                description: WebhookSecretRef represents a secret that should be used
+                  for the webhook
+                properties:
+                  key:
+                    description: Key is the key in the secret's data map for this
+                      value
+                    type: string
+                  name:
+                    description: Name of the kubernetes secret to use
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            required:
+            - credentialsName
+            - webhookSecretRef
+            type: object
+          status:
+            description: EnterpriseStatus defines the observed state of Enterprise
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              id:
+                type: string
+            required:
+            - id
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Enterprise ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Error
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.reason=='PoolManagerFailure')].message
+      name: Pool_Manager_Failure
+      priority: 1
+      type: string
+    - description: Time duration since creation of Enterprise
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Enterprise is the Schema for the enterprises API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EnterpriseSpec defines the desired state of Enterprise
+            properties:
+              credentialsRef:
+                description: |-
+                  TypedLocalObjectReference contains enough information to let you locate the
+                  typed referenced object inside the same namespace.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              poolBalancerType:
+                type: string
+              webhookSecretRef:
+                description: WebhookSecretRef represents a secret that should be used
+                  for the webhook
+                properties:
+                  key:
+                    description: Key is the key in the secret's data map for this
+                      value
+                    type: string
+                  name:
+                    description: Name of the kubernetes secret to use
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            required:
+            - credentialsRef
+            - webhookSecretRef
+            type: object
+          status:
+            description: EnterpriseStatus defines the observed state of Enterprise
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              id:
+                type: string
+            required:
+            - id
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/garm-operator/templates/crd/garmserverconfigs.garm-operator.mercedes-benz.com.yaml
+++ b/charts/garm-operator/templates/crd/garmserverconfigs.garm-operator.mercedes-benz.com.yaml
@@ -1,0 +1,169 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/garm-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: garmserverconfigs.garm-operator.mercedes-benz.com
+spec:
+  group: garm-operator.mercedes-benz.com
+  names:
+    categories:
+    - garm
+    kind: GarmServerConfig
+    listKind: GarmServerConfigList
+    plural: garmserverconfigs
+    singular: garmserverconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Controller ID
+      jsonPath: .status.controllerId
+      name: ID
+      type: string
+    - description: Garm Version
+      jsonPath: .status.version
+      name: Version
+      type: string
+    - description: MetadataURL
+      jsonPath: .status.metadataUrl
+      name: MetadataURL
+      priority: 1
+      type: string
+    - description: CallbackURL
+      jsonPath: .status.callbackUrl
+      name: CallbackURL
+      priority: 1
+      type: string
+    - description: WebhookURL
+      jsonPath: .status.webhookUrl
+      name: WebhookURL
+      priority: 1
+      type: string
+    - description: ControllerWebhookURL
+      jsonPath: .status.controllerWebhookUrl
+      name: ControllerWebhookURL
+      priority: 1
+      type: string
+    - description: Time duration since creation of GarmServerConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GarmServerConfig is the Schema for the garmserverconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GarmServerConfigSpec defines the desired state of GarmServerConfig
+            properties:
+              callbackUrl:
+                type: string
+              metadataUrl:
+                type: string
+              webhookUrl:
+                type: string
+            type: object
+          status:
+            description: GarmServerConfigStatus defines the observed state of GarmServerConfig
+            properties:
+              callbackUrl:
+                type: string
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              controllerId:
+                type: string
+              controllerWebhookUrl:
+                type: string
+              hostname:
+                type: string
+              metadataUrl:
+                type: string
+              minimumJobAgeBackoff:
+                type: integer
+              version:
+                type: string
+              webhookUrl:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/garm-operator/templates/crd/githubcredentials.garm-operator.mercedes-benz.com.yaml
+++ b/charts/garm-operator/templates/crd/githubcredentials.garm-operator.mercedes-benz.com.yaml
@@ -1,0 +1,231 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/garm-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: githubcredentials.garm-operator.mercedes-benz.com
+spec:
+  group: garm-operator.mercedes-benz.com
+  names:
+    categories:
+    - garm
+    kind: GitHubCredential
+    listKind: GitHubCredentialList
+    plural: githubcredentials
+    singular: githubcredential
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Credentials ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Error
+      priority: 1
+      type: string
+    - description: Authentication type
+      jsonPath: .spec.authType
+      name: AuthType
+      type: string
+    - description: GitHubEndpoint name these credentials are tied to
+      jsonPath: .spec.endpointRef.name
+      name: GitHubEndpoint
+      type: string
+    - description: Repositories these credentials are tied to
+      jsonPath: .status.repositories
+      name: Repositories
+      priority: 1
+      type: string
+    - description: Organizations these credentials are tied to
+      jsonPath: .status.organizations
+      name: Organizations
+      priority: 1
+      type: string
+    - description: Enterprises these credentials are tied to
+      jsonPath: .status.enterprises
+      name: Enterprises
+      priority: 1
+      type: string
+    - description: Time duration since creation of GitHubCredential
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GitHubCredential is the Schema for the githubcredential API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitHubCredentialSpec defines the desired state of GitHubCredential
+            properties:
+              appId:
+                description: if AuthType is app
+                format: int64
+                type: integer
+              authType:
+                description: either pat or app
+                type: string
+              description:
+                type: string
+              endpointRef:
+                description: |-
+                  TypedLocalObjectReference contains enough information to let you locate the
+                  typed referenced object inside the same namespace.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              installationId:
+                format: int64
+                type: integer
+              secretRef:
+                description: containing either privateKey or pat token
+                properties:
+                  key:
+                    description: Key is the key in the secret's data map for this
+                      value
+                    type: string
+                  name:
+                    description: Name of the kubernetes secret to use
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            required:
+            - authType
+            - description
+            - endpointRef
+            type: object
+          status:
+            description: GitHubCredentialStatus defines the observed state of GitHubCredential
+            properties:
+              apiBaseUrl:
+                type: string
+              baseUrl:
+                type: string
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              enterprises:
+                items:
+                  type: string
+                type: array
+              id:
+                format: int64
+                type: integer
+              organizations:
+                items:
+                  type: string
+                type: array
+              repositories:
+                items:
+                  type: string
+                type: array
+              uploadBaseUrl:
+                type: string
+            required:
+            - apiBaseUrl
+            - baseUrl
+            - id
+            - uploadBaseUrl
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/garm-operator/templates/crd/githubendpoints.garm-operator.mercedes-benz.com.yaml
+++ b/charts/garm-operator/templates/crd/githubendpoints.garm-operator.mercedes-benz.com.yaml
@@ -1,0 +1,151 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/garm-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: githubendpoints.garm-operator.mercedes-benz.com
+spec:
+  group: garm-operator.mercedes-benz.com
+  names:
+    categories:
+    - garm
+    kind: GitHubEndpoint
+    listKind: GitHubEndpointList
+    plural: githubendpoints
+    singular: githubendpoint
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: API Base URL
+      jsonPath: .spec.apiBaseUrl
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Error
+      priority: 1
+      type: string
+    - description: Time duration since creation of GitHubEndpoint
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GitHubEndpoint is the Schema for the githubendpoints API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitHubEndpointSpec defines the desired state of GitHubEndpoint
+            properties:
+              apiBaseUrl:
+                type: string
+              baseUrl:
+                type: string
+              caCertBundleSecretRef:
+                properties:
+                  key:
+                    description: Key is the key in the secret's data map for this
+                      value
+                    type: string
+                  name:
+                    description: Name of the kubernetes secret to use
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+              description:
+                type: string
+              uploadBaseUrl:
+                type: string
+            type: object
+          status:
+            description: GitHubEndpointStatus defines the observed state of GitHubEndpoint
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/garm-operator/templates/crd/images.garm-operator.mercedes-benz.com.yaml
+++ b/charts/garm-operator/templates/crd/images.garm-operator.mercedes-benz.com.yaml
@@ -1,0 +1,119 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/garm-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: images.garm-operator.mercedes-benz.com
+spec:
+  group: garm-operator.mercedes-benz.com
+  names:
+    categories:
+    - garm
+    kind: Image
+    listKind: ImageList
+    plural: images
+    singular: image
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.tag
+      name: Tag
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Image is the Schema for the images API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImageSpec defines the desired state of Image
+            properties:
+              tag:
+                description: |-
+                  Tag is the Name of the image in its registry
+                  e.g.
+                  - in openstack it can be the image name or id
+                  - in k8s it can be the docker image name + tag
+                type: string
+            type: object
+          status:
+            description: ImageStatus defines the observed state of Image
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.tag
+      name: Tag
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Image is the Schema for the images API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImageSpec defines the desired state of Image
+            properties:
+              tag:
+                description: |-
+                  Tag is the Name of the image in its registry
+                  e.g.
+                  - in openstack it can be the image name or id
+                  - in k8s it can be the docker image name + tag
+                type: string
+            type: object
+          status:
+            description: ImageStatus defines the observed state of Image
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+{{- end }}

--- a/charts/garm-operator/templates/crd/organizations.garm-operator.mercedes-benz.com.yaml
+++ b/charts/garm-operator/templates/crd/organizations.garm-operator.mercedes-benz.com.yaml
@@ -1,0 +1,329 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/garm-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: organizations.garm-operator.mercedes-benz.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: garm-operator-webhook-service
+          namespace: {{ .Release.Namespace }}
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: garm-operator.mercedes-benz.com
+  names:
+    categories:
+    - garm
+    kind: Organization
+    listKind: OrganizationList
+    plural: organizations
+    shortNames:
+    - org
+    singular: organization
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organization ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Error
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.reason=='PoolManagerFailure')].message
+      name: Pool_Manager_Failure
+      priority: 1
+      type: string
+    - description: Time duration since creation of Organization
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Organization is the Schema for the organizations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OrganizationSpec defines the desired state of Organization
+            properties:
+              credentialsName:
+                type: string
+              webhookSecretRef:
+                description: WebhookSecretRef represents a secret that should be used
+                  for the webhook
+                properties:
+                  key:
+                    description: Key is the key in the secret's data map for this
+                      value
+                    type: string
+                  name:
+                    description: Name of the kubernetes secret to use
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            required:
+            - credentialsName
+            - webhookSecretRef
+            type: object
+          status:
+            description: OrganizationStatus defines the observed state of Organization
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              id:
+                type: string
+            required:
+            - id
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Organization ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Error
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.reason=='PoolManagerFailure')].message
+      name: Pool_Manager_Failure
+      priority: 1
+      type: string
+    - description: Time duration since creation of Organization
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Organization is the Schema for the organizations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OrganizationSpec defines the desired state of Organization
+            properties:
+              credentialsRef:
+                description: |-
+                  TypedLocalObjectReference contains enough information to let you locate the
+                  typed referenced object inside the same namespace.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              poolBalancerType:
+                type: string
+              webhookSecretRef:
+                description: WebhookSecretRef represents a secret that should be used
+                  for the webhook
+                properties:
+                  key:
+                    description: Key is the key in the secret's data map for this
+                      value
+                    type: string
+                  name:
+                    description: Name of the kubernetes secret to use
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            required:
+            - credentialsRef
+            - webhookSecretRef
+            type: object
+          status:
+            description: OrganizationStatus defines the observed state of Organization
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              id:
+                type: string
+            required:
+            - id
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/garm-operator/templates/crd/pools.garm-operator.mercedes-benz.com.yaml
+++ b/charts/garm-operator/templates/crd/pools.garm-operator.mercedes-benz.com.yaml
@@ -1,0 +1,465 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/garm-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: pools.garm-operator.mercedes-benz.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: garm-operator-webhook-service
+          namespace: {{ .Release.Namespace }}
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: garm-operator.mercedes-benz.com
+  names:
+    categories:
+    - garm
+    kind: Pool
+    listKind: PoolList
+    plural: pools
+    singular: pool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.id
+      name: ID
+      type: string
+    - jsonPath: .spec.minIdleRunners
+      name: MinIdleRunners
+      type: string
+    - jsonPath: .spec.maxRunners
+      name: MaxRunners
+      type: string
+    - jsonPath: .spec.imageName
+      name: ImageName
+      priority: 1
+      type: string
+    - jsonPath: .spec.flavor
+      name: Flavor
+      priority: 1
+      type: string
+    - jsonPath: .spec.providerName
+      name: Provider
+      priority: 1
+      type: string
+    - jsonPath: .spec.githubScopeRef.kind
+      name: ScopeType
+      priority: 1
+      type: string
+    - jsonPath: .spec.githubScopeRef.name
+      name: ScopeName
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Error
+      priority: 1
+      type: string
+    - jsonPath: .spec.enabled
+      name: Enabled
+      priority: 1
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Pool is the Schema for the pools API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              enabled:
+                type: boolean
+              extraSpecs:
+                type: string
+              flavor:
+                type: string
+              githubRunnerGroup:
+                type: string
+              githubScopeRef:
+                description: Defines in which Scope Runners a registered. Has a reference
+                  to either an Enterprise, Org or Repo CRD
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              imageName:
+                description: The name of the image resource, this image resource must
+                  exists in the same namespace as the pool
+                type: string
+              maxRunners:
+                type: integer
+              minIdleRunners:
+                default: 0
+                type: integer
+              osArch:
+                type: string
+              osType:
+                type: string
+              providerName:
+                type: string
+              runnerBootstrapTimeout:
+                type: integer
+              runnerPrefix:
+                type: string
+              tags:
+                items:
+                  type: string
+                type: array
+            required:
+            - enabled
+            - flavor
+            - githubScopeRef
+            - imageName
+            - maxRunners
+            - minIdleRunners
+            - osArch
+            - osType
+            - providerName
+            - runnerBootstrapTimeout
+            - tags
+            type: object
+            x-kubernetes-validations:
+            - message: minIdleRunners must be less than or equal to maxRunners
+              rule: self.minIdleRunners <= self.maxRunners
+          status:
+            description: PoolStatus defines the observed state of Pool
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              id:
+                type: string
+              longRunningIdleRunners:
+                type: integer
+              selector:
+                type: string
+            required:
+            - id
+            - longRunningIdleRunners
+            - selector
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.minIdleRunners
+        statusReplicasPath: .status.longRunningIdleRunners
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.id
+      name: ID
+      type: string
+    - jsonPath: .spec.minIdleRunners
+      name: MinIdleRunners
+      type: string
+    - jsonPath: .spec.maxRunners
+      name: MaxRunners
+      type: string
+    - jsonPath: .spec.imageName
+      name: ImageName
+      priority: 1
+      type: string
+    - jsonPath: .spec.flavor
+      name: Flavor
+      priority: 1
+      type: string
+    - jsonPath: .spec.providerName
+      name: Provider
+      priority: 1
+      type: string
+    - jsonPath: .spec.githubScopeRef.kind
+      name: ScopeType
+      priority: 1
+      type: string
+    - jsonPath: .spec.githubScopeRef.name
+      name: ScopeName
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Error
+      priority: 1
+      type: string
+    - jsonPath: .spec.enabled
+      name: Enabled
+      priority: 1
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Pool is the Schema for the pools API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              enabled:
+                type: boolean
+              extraSpecs:
+                type: string
+              flavor:
+                type: string
+              githubRunnerGroup:
+                type: string
+              githubScopeRef:
+                description: Defines in which Scope Runners a registered. Has a reference
+                  to either an Enterprise, Org or Repo CRD
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              imageName:
+                description: The name of the image resource, this image resource must
+                  exists in the same namespace as the pool
+                type: string
+              maxRunners:
+                type: integer
+              minIdleRunners:
+                default: 0
+                type: integer
+              osArch:
+                type: string
+              osType:
+                type: string
+              providerName:
+                type: string
+              runnerBootstrapTimeout:
+                type: integer
+              runnerPrefix:
+                type: string
+              tags:
+                items:
+                  type: string
+                type: array
+            required:
+            - enabled
+            - flavor
+            - githubScopeRef
+            - imageName
+            - maxRunners
+            - minIdleRunners
+            - osArch
+            - osType
+            - providerName
+            - runnerBootstrapTimeout
+            - tags
+            type: object
+            x-kubernetes-validations:
+            - message: minIdleRunners must be less than or equal to maxRunners
+              rule: self.minIdleRunners <= self.maxRunners
+          status:
+            description: PoolStatus defines the observed state of Pool
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              id:
+                type: string
+              longRunningIdleRunners:
+                type: integer
+              selector:
+                type: string
+            required:
+            - id
+            - longRunningIdleRunners
+            - selector
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.minIdleRunners
+        statusReplicasPath: .status.longRunningIdleRunners
+      status: {}
+{{- end }}

--- a/charts/garm-operator/templates/crd/repositories.garm-operator.mercedes-benz.com.yaml
+++ b/charts/garm-operator/templates/crd/repositories.garm-operator.mercedes-benz.com.yaml
@@ -1,0 +1,335 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/garm-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: repositories.garm-operator.mercedes-benz.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: garm-operator-webhook-service
+          namespace: {{ .Release.Namespace }}
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: garm-operator.mercedes-benz.com
+  names:
+    categories:
+    - garm
+    kind: Repository
+    listKind: RepositoryList
+    plural: repositories
+    shortNames:
+    - repo
+    singular: repository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Repository ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Error
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.reason=='PoolManagerFailure')].message
+      name: Pool_Manager_Failure
+      priority: 1
+      type: string
+    - description: Time duration since creation of Repository
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Repository is the Schema for the repositories API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RepositorySpec defines the desired state of Repository
+            properties:
+              credentialsName:
+                type: string
+              owner:
+                type: string
+              webhookSecretRef:
+                description: WebhookSecretRef represents a secret that should be used
+                  for the webhook
+                properties:
+                  key:
+                    description: Key is the key in the secret's data map for this
+                      value
+                    type: string
+                  name:
+                    description: Name of the kubernetes secret to use
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            required:
+            - credentialsName
+            - owner
+            - webhookSecretRef
+            type: object
+          status:
+            description: RepositoryStatus defines the observed state of Repository
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              id:
+                type: string
+            required:
+            - id
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Repository ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Error
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.reason=='PoolManagerFailure')].message
+      name: Pool_Manager_Failure
+      priority: 1
+      type: string
+    - description: Time duration since creation of Repository
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Repository is the Schema for the repositories API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RepositorySpec defines the desired state of Repository
+            properties:
+              credentialsRef:
+                description: |-
+                  TypedLocalObjectReference contains enough information to let you locate the
+                  typed referenced object inside the same namespace.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              owner:
+                type: string
+              poolBalancerType:
+                type: string
+              webhookSecretRef:
+                description: WebhookSecretRef represents a secret that should be used
+                  for the webhook
+                properties:
+                  key:
+                    description: Key is the key in the secret's data map for this
+                      value
+                    type: string
+                  name:
+                    description: Name of the kubernetes secret to use
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            required:
+            - credentialsRef
+            - owner
+            - webhookSecretRef
+            type: object
+          status:
+            description: RepositoryStatus defines the observed state of Repository
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              id:
+                type: string
+            required:
+            - id
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/garm-operator/templates/crd/runners.garm-operator.mercedes-benz.com.yaml
+++ b/charts/garm-operator/templates/crd/runners.garm-operator.mercedes-benz.com.yaml
@@ -1,0 +1,357 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/garm-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: runners.garm-operator.mercedes-benz.com
+spec:
+  group: garm-operator.mercedes-benz.com
+  names:
+    categories:
+    - garm
+    kind: Runner
+    listKind: RunnerList
+    plural: runners
+    shortNames:
+    - run
+    singular: runner
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Runner ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Pool CR Name
+      jsonPath: .status.poolId
+      name: Pool
+      type: string
+    - description: Garm Runner Status
+      jsonPath: .status.status
+      name: Garm Runner Status
+      type: string
+    - description: Provider Runner Status
+      jsonPath: .status.instanceStatus
+      name: Provider Runner Status
+      type: string
+    - description: Provider ID
+      jsonPath: .status.providerId
+      name: Provider ID
+      priority: 1
+      type: string
+    - description: Agent ID
+      jsonPath: .status.agentId
+      name: Agent ID
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta1 instead.
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Runner is the Schema for the runners API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RunnerSpec defines the desired state of Runner
+            type: object
+          status:
+            description: RunnerStatus defines the observed state of Runner
+            properties:
+              addresses:
+                description: |-
+                  Addresses is a list of IP addresses the provider reports
+                  for this instance.
+                items:
+                  properties:
+                    address:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              agentId:
+                description: AgentID is the github runner agent ID.
+                format: int64
+                type: integer
+              githubRunnerGroup:
+                description: |-
+                  GithubRunnerGroup is the github runner group to which the runner belongs.
+                  The runner group must be created by someone with access to the enterprise.
+                type: string
+              id:
+                description: ID is the database ID of this instance.
+                type: string
+              instanceStatus:
+                description: 'InstanceStatus of the instance inside the respective
+                  cloud provider of the physical instance (eg: running, stopped, ...)'
+                type: string
+              name:
+                description: |-
+                  Name is the name associated with an instance. Depending on
+                  the provider, this may or may not be useful in the context of
+                  the provider, but we can use it internally to identify the
+                  instance.
+                type: string
+              osArch:
+                description: OSArch is the operating system architecture.
+                type: string
+              osName:
+                description: 'OSName is the name of the OS. Eg: ubuntu, centos, etc.'
+                type: string
+              osType:
+                description: |-
+                  OSType is the operating system type. For now, only Linux and
+                  Windows are supported.
+                type: string
+              osVersion:
+                description: OSVersion is the version of the operating system.
+                type: string
+              poolId:
+                description: PoolID is the ID of the garm pool to which a runner belongs.
+                type: string
+              providerFault:
+                description: |-
+                  ProviderFault holds any error messages captured from the IaaS provider that is
+                  responsible for managing the lifecycle of the runner.
+                type: string
+              providerId:
+                description: |-
+                  PeoviderID is the unique ID the provider associated
+                  with the compute instance. We use this to identify the
+                  instance in the provider.
+                type: string
+              status:
+                description: Status is the runner status as it appears on GitHub.
+                  (idle, pending, ...)
+                type: string
+            required:
+            - agentId
+            - githubRunnerGroup
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Runner ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Pool CR Name
+      jsonPath: .status.poolId
+      name: Pool
+      type: string
+    - description: Garm Runner Status
+      jsonPath: .status.status
+      name: Garm Runner Status
+      type: string
+    - description: Provider Runner Status
+      jsonPath: .status.instanceStatus
+      name: Provider Runner Status
+      type: string
+    - description: Provider ID
+      jsonPath: .status.providerId
+      name: Provider ID
+      priority: 1
+      type: string
+    - description: Agent ID
+      jsonPath: .status.agentId
+      name: Agent ID
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Runner is the Schema for the runners API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RunnerSpec defines the desired state of Runner
+            type: object
+          status:
+            description: RunnerStatus defines the observed state of Runner
+            properties:
+              addresses:
+                description: |-
+                  Addresses is a list of IP addresses the provider reports
+                  for this instance.
+                items:
+                  properties:
+                    address:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              agentId:
+                description: AgentID is the github runner agent ID.
+                format: int64
+                type: integer
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              githubRunnerGroup:
+                description: |-
+                  GithubRunnerGroup is the github runner group to which the runner belongs.
+                  The runner group must be created by someone with access to the enterprise.
+                type: string
+              id:
+                description: ID is the database ID of this instance.
+                type: string
+              instanceStatus:
+                description: 'InstanceStatus of the instance inside the respective
+                  cloud provider of the physical instance (eg: running, stopped, ...)'
+                type: string
+              name:
+                description: |-
+                  Name is the name associated with an instance. Depending on
+                  the provider, this may or may not be useful in the context of
+                  the provider, but we can use it internally to identify the
+                  instance.
+                type: string
+              osArch:
+                description: OSArch is the operating system architecture.
+                type: string
+              osName:
+                description: 'OSName is the name of the OS. Eg: ubuntu, centos, etc.'
+                type: string
+              osType:
+                description: |-
+                  OSType is the operating system type. For now, only Linux and
+                  Windows are supported.
+                type: string
+              osVersion:
+                description: OSVersion is the version of the operating system.
+                type: string
+              poolId:
+                description: PoolID is the ID of the garm pool to which a runner belongs.
+                type: string
+              providerFault:
+                description: |-
+                  ProviderFault holds any error messages captured from the IaaS provider that is
+                  responsible for managing the lifecycle of the runner.
+                type: string
+              providerId:
+                description: |-
+                  PeoviderID is the unique ID the provider associated
+                  with the compute instance. We use this to identify the
+                  instance in the provider.
+                type: string
+              status:
+                description: Status is the runner status as it appears on GitHub.
+                  (idle, pending, ...)
+                type: string
+            required:
+            - agentId
+            - githubRunnerGroup
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/garm-operator/templates/manager/deployment.yaml
+++ b/charts/garm-operator/templates/manager/deployment.yaml
@@ -1,0 +1,184 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: manager
+spec:
+  replicas: {{ .Values.manager.replicas }}
+  selector:
+    matchLabels:
+      {{- include "garm-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.manager.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "garm-operator.labels" . | nindent 8 }}
+        app.kubernetes.io/component: manager
+        {{- with .Values.manager.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.manager.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "garm-operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.manager.podSecurityContext | nindent 8 }}
+      containers:
+        - name: manager
+          command:
+            - /manager
+          {{- with .Values.operator.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.manager.securityContext | nindent 12 }}
+          env:
+            {{- if or .Values.garm.existingSecret .Values.garm.password }}
+            - name: GARM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "garm-operator.secretName" . }}
+                  key: {{ .Values.garm.secretKeys.passwordKey }}
+            {{- end }}
+            {{- if .Values.garm.server }}
+            - name: GARM_SERVER
+              value: {{ .Values.garm.server | quote }}
+            {{- else if .Values.garm.existingSecret }}
+            - name: GARM_SERVER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "garm-operator.secretName" . }}
+                  key: {{ .Values.garm.secretKeys.serverKey }}
+                  optional: true
+            {{- end }}
+            {{- if .Values.garm.username }}
+            - name: GARM_USERNAME
+              value: {{ .Values.garm.username | quote }}
+            {{- else if .Values.garm.existingSecret }}
+            - name: GARM_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "garm-operator.secretName" . }}
+                  key: {{ .Values.garm.secretKeys.usernameKey }}
+                  optional: true
+            {{- end }}
+            {{- if .Values.garm.init }}
+            - name: GARM_INIT
+              value: {{ .Values.garm.init | quote }}
+            {{- end }}
+            {{- if .Values.garm.email }}
+            - name: GARM_EMAIL
+              value: {{ .Values.garm.email | quote }}
+            {{- end }}
+            {{- if .Values.operator.watchNamespace }}
+            - name: OPERATOR_WATCH_NAMESPACE
+              value: {{ .Values.operator.watchNamespace | quote }}
+            {{- end }}
+            - name: OPERATOR_METRICS_BIND_ADDRESS
+              value: {{ .Values.operator.metricsBindAddress | quote }}
+            - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
+              value: {{ .Values.operator.healthProbeBindAddress | quote }}
+            - name: OPERATOR_LEADER_ELECTION
+              value: {{ .Values.operator.leaderElection | quote }}
+            - name: OPERATOR_SYNC_PERIOD
+              value: {{ .Values.operator.syncPeriod | quote }}
+            - name: OPERATOR_SYNC_RUNNERS_INTERVAL
+              value: {{ .Values.operator.syncRunnersInterval | quote }}
+            - name: OPERATOR_MIN_IDLE_RUNNERS_AGE
+              value: {{ .Values.operator.minIdleRunnersAge | quote }}
+            - name: OPERATOR_RUNNER_CONCURRENCY
+              value: {{ .Values.operator.runnerConcurrency | quote }}
+            - name: OPERATOR_REPOSITORY_CONCURRENCY
+              value: {{ .Values.operator.repositoryConcurrency | quote }}
+            - name: OPERATOR_ORGANIZATION_CONCURRENCY
+              value: {{ .Values.operator.organizationConcurrency | quote }}
+            - name: OPERATOR_ENTERPRISE_CONCURRENCY
+              value: {{ .Values.operator.enterpriseConcurrency | quote }}
+            - name: OPERATOR_POOL_CONCURRENCY
+              value: {{ .Values.operator.poolConcurrency | quote }}
+            - name: OPERATOR_RUNNER_RECONCILIATION
+              value: {{ .Values.operator.runnerReconciliation | quote }}
+            - name: OPERATOR_LOG_VERBOSITY_LEVEL
+              value: {{ .Values.operator.logVerbosityLevel | quote }}
+            {{- with .Values.operator.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.operator.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.webhook.enable }}
+          ports:
+            - containerPort: {{ .Values.webhook.port }}
+              name: webhook-server
+              protocol: TCP
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.manager.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.webhook.enable }}
+            - name: cert
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
+            {{- end }}
+            - name: serviceaccount-volume
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      volumes:
+        {{- if .Values.webhook.enable }}
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: webhook-server-cert
+        {{- end }}
+        - name: serviceaccount-volume
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 600
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+      {{- with .Values.manager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.manager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.manager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/garm-operator/templates/manager/secret.yaml
+++ b/charts/garm-operator/templates/manager/secret.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.garm.password (not .Values.garm.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-garm-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.garm.secretKeys.passwordKey }}: {{ .Values.garm.password | quote }}
+  {{- if .Values.garm.username }}
+  {{ .Values.garm.secretKeys.usernameKey }}: {{ .Values.garm.username | quote }}
+  {{- end }}
+  {{- if .Values.garm.server }}
+  {{ .Values.garm.secretKeys.serverKey }}: {{ .Values.garm.server | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/garm-operator/templates/monitoring/kube-state-metrics-configmap.yaml
+++ b/charts/garm-operator/templates/monitoring/kube-state-metrics-configmap.yaml
@@ -1,0 +1,437 @@
+{{- if .Values.kubeStateMetrics.createConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-kube-state-metrics-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: kube-state-metrics
+data:
+  config.yaml: |
+    kind: CustomResourceStateMetrics
+    spec:
+      resources:
+        ##################
+        #   ENTERPRISE   #
+        ##################
+        - groupVersionKind:
+            group: garm-operator.mercedes-benz.com
+            kind: "Enterprise"
+            version: "v1beta1"
+          metricNamePrefix: garm_operator
+          commonLabels:
+            crd_type: "enterprise"
+          labelsFromPath:
+            name: [ metadata, name ]
+            namespace: [ metadata, namespace ]
+          metrics:
+            - name: enterprise_created
+              help: Unix creation timestamp.
+              each:
+                gauge:
+                  path:
+                    - metadata
+                    - creationTimestamp
+                type: Gauge
+            - name: enterprise_info
+              help: Information about an enterprise.
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    credentialsRefName: [ spec, credentialsRef, name ]
+                    webhookSecretRefKey: [ spec, webhookSecretRef, key ]
+                    webhookSecretRefName: [ spec, webhookSecretRef, name ]
+                    id: [ status, id ]
+            - name: enterprise_annotation_paused_info
+              help: Whether the enterprise reconciliation is paused.
+              each:
+                type: Info
+                info:
+                  path:
+                    - metadata
+                    - annotations
+                    - garm-operator.mercedes-benz.com/paused
+                  labelsFromPath:
+                    paused_value: []
+            - name: enterprise_status_conditions
+              help: Displays whether status of each possible condition is True or False.
+              each:
+                type: Gauge
+                gauge:
+                  path:
+                    - status
+                    - conditions
+                  valueFrom:
+                    - status
+                  labelFromKey: reason
+                  labelsFromPath:
+                    type: [ type ]
+        #################
+        #      Org      #
+        #################
+        - groupVersionKind:
+            group: garm-operator.mercedes-benz.com
+            kind: "Organization"
+            version: "v1beta1"
+          metricNamePrefix: garm_operator
+          commonLabels:
+            crd_type: "organization"
+          labelsFromPath:
+            name: [ metadata, name ]
+            namespace: [ metadata, namespace ]
+          metrics:
+            - name: org_created
+              help: Unix creation timestamp.
+              each:
+                gauge:
+                  path:
+                    - metadata
+                    - creationTimestamp
+                type: Gauge
+            - name: org_info
+              help: Information about an organization.
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    credentialsRefName: [ spec, credentialsRef, name ]
+                    webhookSecretRefKey: [ spec, webhookSecretRef, key ]
+                    webhookSecretRefName: [ spec, webhookSecretRef, name ]
+                    id: [ status, id ]
+            - name: org_annotation_paused_info
+              help: Whether the org reconciliation is paused.
+              each:
+                type: Info
+                info:
+                  path:
+                    - metadata
+                    - annotations
+                    - garm-operator.mercedes-benz.com/paused
+                  labelsFromPath:
+                    paused_value: [ ]
+            - name: org_status_conditions
+              help: Displays whether status of each possible condition is True or False.
+              each:
+                type: Gauge
+                gauge:
+                  path:
+                    - status
+                    - conditions
+                  valueFrom:
+                    - status
+                  labelFromKey: reason
+                  labelsFromPath:
+                    type: [ type ]
+        ##################
+        #      Repo      #
+        ##################
+        - groupVersionKind:
+            group: garm-operator.mercedes-benz.com
+            kind: "Repository"
+            version: "v1beta1"
+          metricNamePrefix: garm_operator
+          commonLabels:
+            crd_type: "repository"
+          labelsFromPath:
+            name: [ metadata, name ]
+            namespace: [ metadata, namespace ]
+          metrics:
+            - name: repo_created
+              help: Unix creation timestamp.
+              each:
+                gauge:
+                  path:
+                    - metadata
+                    - creationTimestamp
+                type: Gauge
+            - name: repo_info
+              help: Information about a repository.
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    owner: [ spec, owner ]
+                    credentialsRefName: [ spec, credentialsRef, name ]
+                    webhookSecretRefKey: [ spec, webhookSecretRef, key ]
+                    webhookSecretRefName: [ spec, webhookSecretRef, name ]
+                    id: [ status, id ]
+            - name: repo_annotation_paused_info
+              help: Whether the repo reconciliation is paused.
+              each:
+                type: Info
+                info:
+                  path:
+                    - metadata
+                    - annotations
+                    - garm-operator.mercedes-benz.com/paused
+                  labelsFromPath:
+                    paused_value: [ ]
+            - name: repo_status_conditions
+              help: Displays whether status of each possible condition is True or False.
+              each:
+                type: Gauge
+                gauge:
+                  path:
+                    - status
+                    - conditions
+                  valueFrom:
+                    - status
+                  labelFromKey: reason
+                  labelsFromPath:
+                    type: [ type ]
+        #################
+        #      Pool     #
+        #################
+        - groupVersionKind:
+            group: garm-operator.mercedes-benz.com
+            kind: "Pool"
+            version: "v1beta1"
+          metricNamePrefix: garm_operator
+          commonLabels:
+            crd_type: "pool"
+          labelsFromPath:
+            name: [ metadata, name ]
+            namespace: [ metadata, namespace ]
+          metrics:
+            - name: pool_created
+              help: Unix creation timestamp.
+              each:
+                gauge:
+                  path:
+                    - metadata
+                    - creationTimestamp
+                type: Gauge
+            - name: pool_info
+              help: Information about a pool.
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    githubRunnerGroup: [spec, githubRunnerGroup]
+                    scopeKind: [spec, githubScopeRef, kind]
+                    scopeName: [spec, githubScopeRef, name]
+                    imageName: [spec, imageName]
+                    osArch: [spec, osArch]
+                    osType: [spec, osType]
+                    providerName: [spec, providerName]
+                    runnerBootstrapTimeout: [spec, runnerBootstrapTimeout]
+                    runnerPrefix: [spec, runnerPrefix]
+                    tags: [spec, tags]
+                    id: [status, id]
+            - name: pool_enabled
+              help: Whether the pool is enabled.
+              each:
+                type: Gauge
+                gauge:
+                  nilIsZero: true
+                  path:
+                    - spec
+                    - enabled
+            - name: pool_min_idle_runners
+              help: Minimum number of idle runners.
+              each:
+                type: Gauge
+                gauge:
+                  path:
+                    - spec
+                    - minIdleRunners
+            - name: pool_max_runners
+              help: Maximum number of runners.
+              each:
+                type: Gauge
+                gauge:
+                  path:
+                    - spec
+                    - maxRunners
+            - name: status_long_running_idle_runners
+              help: Number of long running idle runners.
+              each:
+                type: Gauge
+                gauge:
+                  path:
+                    - status
+                    - longRunningIdleRunners
+            - name: pool_annotation_paused_info
+              help: Whether the pool reconciliation is paused.
+              each:
+                type: Info
+                info:
+                  path:
+                    - metadata
+                    - annotations
+                    - garm-operator.mercedes-benz.com/paused
+                  labelsFromPath:
+                    paused_value: [ ]
+            - name: pool_status_conditions
+              help: Displays whether status of each possible condition is True or False.
+              each:
+                type: Gauge
+                gauge:
+                  path:
+                    - status
+                    - conditions
+                  valueFrom:
+                    - status
+                  labelFromKey: reason
+                  labelsFromPath:
+                    type: [ type ]
+        ##################
+        #      Image    #
+        ##################
+        - groupVersionKind:
+            group: garm-operator.mercedes-benz.com
+            kind: "Image"
+            version: "v1beta1"
+          metricNamePrefix: garm_operator
+          commonLabels:
+            crd_type: "image"
+          labelsFromPath:
+            name: [ metadata, name ]
+            namespace: [ metadata, namespace ]
+          metrics:
+            - name: image_created
+              help: Unix creation timestamp.
+              each:
+                gauge:
+                  path:
+                    - metadata
+                    - creationTimestamp
+                type: Gauge
+            - name: image_info
+              help: Information about an image.
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    tag: [spec, tag]
+        ############################
+        #      GarmServerConfig    #
+        ############################
+        - groupVersionKind:
+            group: garm-operator.mercedes-benz.com
+            kind: "GarmServerConfig"
+            version: "v1beta1"
+          metricNamePrefix: garm_operator
+          commonLabels:
+            crd_type: "garmserverconfig"
+          labelsFromPath:
+            name: [ metadata, name ]
+            namespace: [ metadata, namespace ]
+          metrics:
+            - name: garmserverconfig_created
+              help: Unix creation timestamp.
+              each:
+                gauge:
+                  path:
+                    - metadata
+                    - creationTimestamp
+                type: Gauge
+            - name: garmserverconfig_info
+              help: Information about a garm server config.
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    callbackUrl: [spec, callbackUrl]
+                    metadataUrl: [spec, metadataUrl]
+                    webhookUrl: [spec, webhookUrl]
+                    controllerId: [status, controllerId]
+                    minimumJobAgeBackoff: [status, minimumJobAgeBackoff]
+                    version: [status, version]
+        ##########################
+        #      GitHubEndpoint    #
+        ##########################
+        - groupVersionKind:
+            group: garm-operator.mercedes-benz.com
+            kind: "GitHubEndpoint"
+            version: "v1beta1"
+          metricNamePrefix: garm_operator
+          commonLabels:
+            crd_type: "githubendpoint"
+          labelsFromPath:
+            name: [ metadata, name ]
+            namespace: [ metadata, namespace ]
+          metrics:
+            - name: githubendpoint_created
+              help: Unix creation timestamp.
+              each:
+                gauge:
+                  path:
+                    - metadata
+                    - creationTimestamp
+                type: Gauge
+            - name: githubendpoint_info
+              help: Information about a githubendpoint config.
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    apiBaseUrl: [spec, apiBaseUrl]
+                    baseUrl: [spec, baseUrl]
+                    uploadBaseUrl: [spec, uploadBaseUrl]
+            - name: githubendpoint_status_conditions
+              help: Displays whether status of each possible condition is True or False.
+              each:
+                type: Gauge
+                gauge:
+                  path:
+                    - status
+                    - conditions
+                  valueFrom:
+                    - status
+                  labelFromKey: reason
+                  labelsFromPath:
+                    type: [ type ]
+        ############################
+        #      GitHubCredential    #
+        ############################
+        - groupVersionKind:
+            group: garm-operator.mercedes-benz.com
+            kind: "GitHubCredential"
+            version: "v1beta1"
+          metricNamePrefix: garm_operator
+          commonLabels:
+            crd_type: "githubcredential"
+          labelsFromPath:
+            name: [ metadata, name ]
+            namespace: [ metadata, namespace ]
+          metrics:
+            - name: githubcredential_created
+              help: Unix creation timestamp.
+              each:
+                gauge:
+                  path:
+                    - metadata
+                    - creationTimestamp
+                type: Gauge
+            - name: githubcredential_info
+              help: Information about a githubcredential config.
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    authType: [spec, authType]
+                    secretRefKey: [ spec, secretRef, key ]
+                    secretRefName: [ spec, secretRef, name ]
+                    endpointRefName: [ spec, endpointRef, name ]
+                    apiBaseUrl: [status, apiBaseUrl]
+                    baseUrl: [status, baseUrl]
+                    uploadBaseUrl: [status, uploadBaseUrl]
+                    id: [status, id]
+            - name: githubcredential_status_conditions
+              help: Displays whether status of each possible condition is True or False.
+              each:
+                type: Gauge
+                gauge:
+                  path:
+                    - status
+                    - conditions
+                  valueFrom:
+                    - status
+                  labelFromKey: reason
+                  labelsFromPath:
+                    type: [ type ]
+{{- end }}

--- a/charts/garm-operator/templates/monitoring/servicemonitor.yaml
+++ b/charts/garm-operator/templates/monitoring/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.prometheus.enable }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-metrics-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    {{- with .Values.prometheus.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+      scheme: http
+      interval: {{ .Values.prometheus.serviceMonitor.interval | default "30s" }}
+  selector:
+    matchLabels:
+      {{- include "garm-operator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/garm-operator/templates/rbac/leader-election-role.yaml
+++ b/charts/garm-operator/templates/rbac/leader-election-role.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+{{- end }}

--- a/charts/garm-operator/templates/rbac/leader-election-rolebinding.yaml
+++ b/charts/garm-operator/templates/rbac/leader-election-rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "garm-operator.fullname" . }}-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "garm-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/garm-operator/templates/rbac/manager-role.yaml
+++ b/charts/garm-operator/templates/rbac/manager-role.yaml
@@ -1,0 +1,157 @@
+{{- if .Values.rbac.create }}
+{{- if empty .Values.operator.watchNamespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-manager-role
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+rules:
+- apiGroups:
+  - ""
+  - "events.k8s.io"
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - garm-operator.mercedes-benz.com
+  resources:
+  - enterprises
+  - garmserverconfigs
+  - githubcredentials
+  - githubendpoints
+  - images
+  - organizations
+  - pools
+  - repositories
+  - runners
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - garm-operator.mercedes-benz.com
+  resources:
+  - enterprises/finalizers
+  - garmserverconfigs/finalizers
+  - githubcredentials/finalizers
+  - githubendpoints/finalizers
+  - organizations/finalizers
+  - repositories/finalizers
+  - runners/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - garm-operator.mercedes-benz.com
+  resources:
+  - enterprises/status
+  - garmserverconfigs/status
+  - githubcredentials/status
+  - githubendpoints/status
+  - organizations/status
+  - pools/status
+  - repositories/status
+  - runners/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-manager-role
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+rules:
+- apiGroups:
+  - ""
+  - "events.k8s.io"
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-manager-role
+  namespace: {{ .Values.operator.watchNamespace | default .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - garm-operator.mercedes-benz.com
+  resources:
+  - enterprises
+  - garmserverconfigs
+  - githubcredentials
+  - githubendpoints
+  - images
+  - organizations
+  - pools
+  - repositories
+  - runners
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - garm-operator.mercedes-benz.com
+  resources:
+  - enterprises/finalizers
+  - garmserverconfigs/finalizers
+  - githubcredentials/finalizers
+  - githubendpoints/finalizers
+  - organizations/finalizers
+  - repositories/finalizers
+  - runners/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - garm-operator.mercedes-benz.com
+  resources:
+  - enterprises/status
+  - garmserverconfigs/status
+  - githubcredentials/status
+  - githubendpoints/status
+  - organizations/status
+  - pools/status
+  - repositories/status
+  - runners/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- end }}
+{{- end }}

--- a/charts/garm-operator/templates/rbac/manager-rolebinding.yaml
+++ b/charts/garm-operator/templates/rbac/manager-rolebinding.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-manager-cluster-rolebinding
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "garm-operator.fullname" . }}-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "garm-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- if .Values.operator.watchNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-manager-rolebinding
+  namespace: {{ .Values.operator.watchNamespace | default .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "garm-operator.fullname" . }}-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "garm-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/garm-operator/templates/rbac/serviceaccount.yaml
+++ b/charts/garm-operator/templates/rbac/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "garm-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/garm-operator/templates/webhook/validating-webhook-configuration.yaml
+++ b/charts/garm-operator/templates/webhook/validating-webhook-configuration.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.webhook.enable }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "garm-operator.fullname" . }}-validating-webhook-configuration
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+  annotations:
+    {{- if .Values.certManager.enable }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "garm-operator.fullname" . }}-serving-cert
+    {{- end }}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "garm-operator.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-garm-operator-mercedes-benz-com-v1beta1-image
+  failurePolicy: Fail
+  name: validate.image.garm-operator.mercedes-benz.com
+  rules:
+  - apiGroups:
+    - garm-operator.mercedes-benz.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - DELETE
+    resources:
+    - images
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "garm-operator.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-garm-operator-mercedes-benz-com-v1beta1-pool
+  failurePolicy: Fail
+  name: validate.pool.garm-operator.mercedes-benz.com
+  rules:
+  - apiGroups:
+    - garm-operator.mercedes-benz.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "garm-operator.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-garm-operator-mercedes-benz-com-v1beta1-repository
+  failurePolicy: Fail
+  name: validate.repository.garm-operator.mercedes-benz.com
+  rules:
+  - apiGroups:
+    - garm-operator.mercedes-benz.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - UPDATE
+    resources:
+    - repositories
+  sideEffects: None
+{{- end }}

--- a/charts/garm-operator/templates/webhook/webhook-service.yaml
+++ b/charts/garm-operator/templates/webhook/webhook-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.webhook.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "garm-operator.webhookServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "garm-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+spec:
+  type: {{ .Values.webhook.service.type }}
+  ports:
+    - port: {{ .Values.webhook.service.port }}
+      protocol: TCP
+      targetPort: {{ .Values.webhook.port }}
+  selector:
+    {{- include "garm-operator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/garm-operator/values.yaml
+++ b/charts/garm-operator/values.yaml
@@ -1,0 +1,171 @@
+# Default values for garm-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# GARM server connection configuration
+garm:
+  # GARM server URL (e.g. http://garm-server:9997)
+  server: ""
+  # GARM admin username
+  username: ""
+  # GARM admin password. If existingSecret is set, this is ignored.
+  password: ""
+  # Reference to an existing Secret containing GARM credentials
+  # The secret should contain the key specified by secretKeys.passwordKey.
+  # It may also optionally contain secretKeys.usernameKey and secretKeys.serverKey.
+  existingSecret: ""
+  # Keys in the Secret (either created or referenced via existingSecret)
+  secretKeys:
+    passwordKey: "password"
+    usernameKey: "username"
+    serverKey: "server"
+  # Initialize GARM on startup (default: false)
+  init: false
+  # GARM admin email (required if init is true)
+  email: ""
+
+# Operator configuration
+operator:
+  # Namespace to watch for custom resources. If left empty, all namespaces are watched.
+  watchNamespace: ""
+  # Address the metric endpoint binds to
+  metricsBindAddress: ":8080"
+  # Address the health probe endpoint binds to
+  healthProbeBindAddress: ":8081"
+  # Enable leader election for controller manager
+  leaderElection: false
+  # Controller manager sync period
+  syncPeriod: "5m0s"
+  # Interval for syncing runners
+  syncRunnersInterval: "5m0s"
+  # Minimum idle runners age before deletion
+  minIdleRunnersAge: "5m0s"
+  # Concurrency settings for reconcilers
+  runnerConcurrency: 20
+  repositoryConcurrency: 5
+  organizationConcurrency: 3
+  enterpriseConcurrency: 1
+  poolConcurrency: 10
+  # Enable runner reconciliation loop
+  runnerReconciliation: true
+  # Log verbosity level (0-5)
+  logVerbosityLevel: 0
+  # Additional arguments to pass to the operator
+  extraArgs: []
+  # Additional environment variables to pass to the operator
+  extraEnv: []
+  # Additional environment variables from configmaps/secrets
+  extraEnvFrom: []
+
+# Controller manager deployment settings
+manager:
+  # Number of replicas
+  replicas: 1
+
+  # Image configuration
+  image:
+    repository: ghcr.io/mercedes-benz/garm-operator/garm-operator
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  # Image pull secrets
+  imagePullSecrets: []
+
+  # Pod annotations
+  podAnnotations:
+    kubectl.kubernetes.io/default-container: manager
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: "8080"
+
+  # Pod labels
+  podLabels: {}
+
+  # Pod security context
+  podSecurityContext:
+    runAsNonRoot: true
+
+  # Container security context
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+  # Resource requests and limits
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+
+  # Node selector
+  nodeSelector: {}
+
+  # Tolerations
+  tolerations: []
+
+  # Affinity
+  affinity: {}
+
+# ServiceAccount configuration
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use. If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+# RBAC configuration
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+# Custom Resource Definitions
+crd:
+  # Specifies whether CRDs should be installed with the chart
+  enable: true
+  # Keep CRDs upon helm uninstall
+  keep: true
+
+# Webhook configuration
+webhook:
+  # Enable admission webhooks
+  enable: true
+  # Port on which the webhook server listens
+  port: 9443
+  # Webhook Service configuration
+  service:
+    type: ClusterIP
+    port: 443
+
+# cert-manager integration for webhook TLS certificates
+certManager:
+  # Enable cert-manager Issuer and Certificate generation
+  enable: true
+  # If specified, use this Issuer instead of creating a self-signed issuer
+  issuerRef: {}
+    # group: cert-manager.io
+    # kind: ClusterIssuer
+    # name: letsencrypt-prod
+
+# Prometheus monitoring configuration
+prometheus:
+  # Enable Prometheus ServiceMonitor
+  enable: false
+  serviceMonitor:
+    interval: "30s"
+    labels: {}
+
+# kube-state-metrics configuration
+kubeStateMetrics:
+  # Deploy CustomResourceStateMetrics ConfigMap for kube-state-metrics
+  createConfigMap: true
+
+# Overrides for names
+nameOverride: ""
+fullnameOverride: ""

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 module github.com/mercedes-benz/garm-operator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cloudbase/garm v0.1.5

--- a/hack/update-chart.sh
+++ b/hack/update-chart.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHART_DIR="${REPO_ROOT}/charts/garm-operator"
+CHART_CRD_DIR="${CHART_DIR}/templates/crd"
+CHART_RBAC_DIR="${CHART_DIR}/templates/rbac"
+CHART_WEBHOOK_DIR="${CHART_DIR}/templates/webhook"
+CHART_MONITORING_DIR="${CHART_DIR}/templates/monitoring"
+TMP_DIR="${REPO_ROOT}/tmp/chart-sync"
+SLICED_DIR="${TMP_DIR}/sliced"
+LOCALBIN="${REPO_ROOT}/bin"
+KUSTOMIZE="${LOCALBIN}/kustomize"
+SLICE="${LOCALBIN}/kubectl-slice"
+
+if [[ ! -x "${KUSTOMIZE}" ]]; then
+  echo "kustomize not found at ${KUSTOMIZE}. Please run 'make kustomize'." >&2
+  exit 1
+fi
+
+if [[ ! -x "${SLICE}" ]]; then
+  echo "kubectl-slice not found at ${SLICE}. Please run 'make slice'." >&2
+  exit 1
+fi
+
+mkdir -p "${SLICED_DIR}" "${CHART_CRD_DIR}" "${CHART_RBAC_DIR}" "${CHART_WEBHOOK_DIR}" "${CHART_MONITORING_DIR}"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+echo "1. Synchronizing Custom Resource Definitions (CRDs)..."
+"${KUSTOMIZE}" build "${REPO_ROOT}/config/default" > "${TMP_DIR}/all.yaml"
+
+"${SLICE}" -f "${TMP_DIR}/all.yaml" \
+  --include-kind CustomResourceDefinition \
+  --template "{{ .metadata.name }}.yaml" \
+  -o "${SLICED_DIR}/"
+
+for crd in "${SLICED_DIR}"/*.yaml; do
+  name="$(basename "${crd}")"
+
+  python3 - "${crd}" "${CHART_CRD_DIR}/${name}" << 'EOF'
+import sys
+import re
+
+src_file = sys.argv[1]
+dst_file = sys.argv[2]
+
+with open(src_file, 'r') as f:
+    content = f.read()
+
+# Replace hardcoded namespace with Helm template
+content = re.sub(
+    r'cert-manager\.io/inject-ca-from:\s*[a-zA-Z0-9_-]+/garm-operator-serving-cert',
+    'cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/garm-operator-serving-cert',
+    content
+)
+content = re.sub(
+    r'service:\n(\s+)name:\s*garm-operator-webhook-service\n\1namespace:\s*[a-zA-Z0-9_-]+',
+    r'service:\n\1name: garm-operator-webhook-service\n\1namespace: {{ .Release.Namespace }}',
+    content
+)
+
+# Insert crd.keep annotation under metadata.annotations if annotations exists
+if 'annotations:' in content:
+    content = content.replace(
+        '  annotations:\n',
+        '  annotations:\n{{- if .Values.crd.keep }}\n    helm.sh/resource-policy: keep\n{{- end }}\n'
+    )
+else:
+    content = content.replace(
+        'metadata:\n',
+        'metadata:\n{{- if .Values.crd.keep }}\n  annotations:\n    helm.sh/resource-policy: keep\n{{- end }}\n'
+    )
+
+output = f"{{{{- if .Values.crd.enable }}}}\n{content.strip()}\n{{{{- end }}}}\n"
+
+with open(dst_file, 'w') as f:
+    f.write(output)
+EOF
+done
+
+echo "2. Synchronizing RBAC rules..."
+python3 - "${REPO_ROOT}/config/rbac/role.yaml" "${CHART_RBAC_DIR}/manager-role.yaml" << 'EOF'
+import sys
+
+src_file = sys.argv[1]
+dst_file = sys.argv[2]
+
+with open(src_file, 'r') as f:
+    content = f.read()
+
+docs = content.split('---')
+cluster_rules = []
+role_rules = []
+
+for doc in docs:
+    lines = doc.strip().splitlines()
+    if not lines:
+        continue
+    is_cluster = any('kind: ClusterRole' in l for l in lines)
+    is_role = any('kind: Role' in l for l in lines)
+    
+    rules_lines = []
+    recording = False
+    for line in lines:
+        if line.strip().startswith('rules:'):
+            recording = True
+            continue
+        if recording:
+            rules_lines.append(line)
+            
+    if is_cluster:
+        cluster_rules = rules_lines
+    elif is_role:
+        role_rules = rules_lines
+
+# Ensure events.k8s.io is included for controller-runtime event broadcaster
+updated_cluster_rules = []
+for line in cluster_rules:
+    updated_cluster_rules.append(line)
+    if line.strip() == '- ""':
+        updated_cluster_rules.append('  - "events.k8s.io"')
+if updated_cluster_rules:
+    cluster_rules = updated_cluster_rules
+
+output = f"""{{{{- if .Values.rbac.create }}}}
+{{{{- if empty .Values.operator.watchNamespace }}}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{{{ include "garm-operator.fullname" . }}}}-manager-role
+  labels:
+    {{{{- include "garm-operator.labels" . | nindent 4 }}}}
+    app.kubernetes.io/component: rbac
+rules:
+""" + '\n'.join(cluster_rules + role_rules) + f"""
+{{{{- else }}}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{{{ include "garm-operator.fullname" . }}}}-manager-role
+  labels:
+    {{{{- include "garm-operator.labels" . | nindent 4 }}}}
+    app.kubernetes.io/component: rbac
+rules:
+""" + '\n'.join(cluster_rules) + f"""
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{{{ include "garm-operator.fullname" . }}}}-manager-role
+  namespace: {{{{ .Values.operator.watchNamespace | default .Release.Namespace }}}}
+  labels:
+    {{{{- include "garm-operator.labels" . | nindent 4 }}}}
+    app.kubernetes.io/component: rbac
+rules:
+""" + '\n'.join(role_rules) + f"""
+{{{{- end }}}}
+{{{{- end }}}}
+"""
+
+with open(dst_file, 'w') as f:
+    f.write(output)
+EOF
+
+echo "3. Synchronizing Webhook configurations..."
+python3 - "${REPO_ROOT}/config/webhook/manifests.yaml" "${CHART_WEBHOOK_DIR}/validating-webhook-configuration.yaml" << 'EOF'
+import sys
+import re
+
+src_file = sys.argv[1]
+dst_file = sys.argv[2]
+
+with open(src_file, 'r') as f:
+    content = f.read()
+
+# Extract webhooks: section
+webhooks_idx = content.find('webhooks:')
+if webhooks_idx != -1:
+    webhooks_content = content[webhooks_idx:]
+else:
+    webhooks_content = "webhooks: []"
+
+webhooks_content = re.sub(
+    r'name:\s*webhook-service',
+    r'name: {{ include "garm-operator.webhookServiceName" . }}',
+    webhooks_content
+)
+webhooks_content = re.sub(
+    r'namespace:\s*system',
+    r'namespace: {{ .Release.Namespace }}',
+    webhooks_content
+)
+
+output = f"""{{{{- if .Values.webhook.enable }}}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{{{ include "garm-operator.fullname" . }}}}-validating-webhook-configuration
+  labels:
+    {{{{- include "garm-operator.labels" . | nindent 4 }}}}
+    app.kubernetes.io/component: webhook
+  annotations:
+    {{{{- if .Values.certManager.enable }}}}
+    cert-manager.io/inject-ca-from: {{{{ .Release.Namespace }}}}/{{{{ include "garm-operator.fullname" . }}}}-serving-cert
+    {{{{- end }}}}
+{webhooks_content.strip()}
+{{{{- end }}}}
+"""
+
+with open(dst_file, 'w') as f:
+    f.write(output)
+EOF
+
+echo "4. Synchronizing kube-state-metrics configuration..."
+python3 - "${REPO_ROOT}/config/kube-state-metrics/configmap.yaml" "${CHART_MONITORING_DIR}/kube-state-metrics-configmap.yaml" << 'EOF'
+import sys
+
+src_file = sys.argv[1]
+dst_file = sys.argv[2]
+
+with open(src_file, 'r') as f:
+    content = f.read()
+
+lines = content.splitlines()
+data_lines = []
+capturing_data = False
+
+for line in lines:
+    if line.startswith('data:'):
+        capturing_data = True
+    if capturing_data:
+        data_lines.append(line)
+
+output = f"""{{{{- if .Values.kubeStateMetrics.createConfigMap }}}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{{{ include "garm-operator.fullname" . }}}}-kube-state-metrics-config
+  namespace: {{{{ .Release.Namespace }}}}
+  labels:
+    {{{{- include "garm-operator.labels" . | nindent 4 }}}}
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: kube-state-metrics
+""" + '\n'.join(data_lines) + f"""
+{{{{- end }}}}
+"""
+
+with open(dst_file, 'w') as f:
+    f.write(output)
+EOF
+
+echo "Helm chart successfully synchronized with Kubebuilder manifests."


### PR DESCRIPTION
Introduce a production-ready Helm chart for garm-operator under charts/garm-operator, with automated synchronization from Kubebuilder manifests, secure secret handling, and CI/CD release integration.

Key additions and changes:
- charts/garm-operator:
  - Complete chart structure (Chart.yaml, values.yaml, templates, README.md).
  - Secure credential handling supporting both values-based generation and referencing an existing Secret (garm.existingSecret) without plain-text leakage.
  - Cert-manager integration with self-signed Issuer and Serving Certificate for TLS webhook termination.
  - Admission ValidatingWebhookConfiguration with cert-manager CA bundle injection.
  - Dual-mode RBAC scoping: ClusterRole for cluster-wide operation (default) or scoped Role/RoleBinding when operator.watchNamespace is configured.
  - Monitoring resources (ServiceMonitor and kube-state-metrics ConfigMap).
  - Templated CRDs with crd.keep annotation support and {{ .Release.Namespace }} injection.
- hack/update-chart.sh:
  - Automated synchronization script keeping CRDs, RBAC, Webhooks, and kube-state-metrics ConfigMap in lockstep with config/.
  - Pure standard-library Python without third-party host dependencies (no PyYAML).
- Makefile:
  - Added make helm target to download and cache bin/helm v3.17.1 locally.
  - Added update-chart, verify-chart, verify-helm, and release-helm targets.
  - Integrated chart and helm checks into ALL_VERIFY_CHECKS.
- .goreleaser.yaml:
  - Added make release-helm hook to package chart into tmp/garm-operator-*.tgz.
- .github/workflows/test-chart.yml:
  - Added CI workflow running helm lint, unit tests, and live Kind installation with cert-manager and mock GARM server.
- README.md & charts/garm-operator/README.md:
  - Comprehensive documentation covering installation, configuration, and secret management.

Fixes #138